### PR TITLE
enhance db design

### DIFF
--- a/db_create_cluster.sql
+++ b/db_create_cluster.sql
@@ -1,0 +1,147 @@
+-- In case we need to drop the schema, make sure to use CASCADE.
+-- DROP SCHEMA IF EXISTS grafana CASCADE;
+
+/*
+  We don't use 'IF NOT EXISTS' in CREATE SCHEMA
+  so that an error will be thrown in case the schema
+  does exist.
+*/
+CREATE SCHEMA grafana;
+
+GRANT usage ON SCHEMA grafana TO grafana;
+GRANT ALL ON ALL TABLES IN SCHEMA grafana TO grafana;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA grafana TO grafana;
+
+
+CREATE TABLE grafana.ts_cluster (
+    report_id           INTEGER REFERENCES public.report(id) PRIMARY KEY,
+    ts                  TIMESTAMP,
+    cluster_id          VARCHAR(50),
+    created             TIMESTAMP, /* cluster creation date */
+    channel_basic       BOOLEAN,
+    channel_crash       BOOLEAN,
+    channel_device      BOOLEAN,
+    channel_ident       BOOLEAN,
+    total_bytes         BIGINT,
+    total_used_bytes    BIGINT,
+    osd_count           INTEGER,
+    mon_count           INTEGER,
+    ipv4_addr_mons      INTEGER,
+    ipv6_addr_mons      INTEGER,
+    v1_addr_mons        INTEGER,
+    v2_addr_mons        INTEGER,
+    rbd_num_pools       INTEGER,
+    fs_count            INTEGER,
+    hosts_num           INTEGER,
+    pools_num           INTEGER,
+    pg_num              INTEGER
+);
+
+CREATE INDEX ON grafana.ts_cluster (ts);
+
+/*
+  The json report's metadata section:
+
+    "metadata": {
+      "osd": {
+        "cpu": {
+          "Intel(R) Xeon(R) CPU E5-2620 v4 @ 2.10GHz": 90
+        },
+      }
+    }
+
+  translates to:
+
+    INSERT INTO metadata (report_id, ts, entity, attr, value, total)
+      VALUES ($report_id, $ts, "osd", "cpu", "Intel(R) Xeon(R) CPU E5-2620 v4 @ 2.10GHz", 90);
+
+  example query - number of different ceph versions per cluster:
+
+    SELECT COUNT(DISTINCT(value)) FROM metadata WHERE report_id=$report_id AND attr='ceph_version';
+*/
+
+CREATE TABLE grafana.metadata (
+    report_id       INTEGER REFERENCES public.report(id) ON DELETE CASCADE,
+    ts              TIMESTAMP,
+    entity          VARCHAR(16),
+    attr            VARCHAR(32),
+    value           VARCHAR(128),
+    total           INTEGER
+);
+
+CREATE TABLE grafana.rbd_pool (
+    report_id       INTEGER REFERENCES public.report(id) ON DELETE CASCADE,
+    ts              TIMESTAMP,
+    pool_idx        INTEGER, /* needs to derive this from the element position in the array */
+    num_images      INTEGER,
+    mirroring       BOOLEAN
+);
+
+CREATE TABLE grafana.pool (
+    report_id                INTEGER REFERENCES public.report(id) ON DELETE CASCADE,
+    ts                       TIMESTAMP,
+    pool_idx                 INTEGER,
+    pgp_num                  INTEGER,
+    pg_num                   INTEGER,
+    size                     BIGINT,
+    min_size                 BIGINT,
+    cache_mode               VARCHAR(32),
+    target_max_objects       BIGINT,
+    target_max_bytes         BIGINT,
+    pg_autoscale_mode        VARCHAR(32),
+    type                     VARCHAR(32),
+
+    /* erasure_code_profile */
+    ec_k                    SMALLINT,
+    ec_m                    SMALLINT,
+    ec_crush_failure_domain VARCHAR(32),
+    ec_plugin               VARCHAR(32),
+    ec_technique            VARCHAR(32)
+);
+
+-- maps major versions ("14", "15") to their name ("Nautilus", "Octopus").
+-- 'version' is of type VARCHAR because there is version "Dev".
+CREATE TABLE grafana.version_to_name (
+    version     VARCHAR(32),
+    name        VARCHAR(32)
+);
+
+INSERT INTO grafana.version_to_name(version, name)
+    VALUES
+        ('12', 'Luminous'),
+        ('13', 'Mimic'),
+        ('14', 'Nautilus'),
+        ('15', 'Octopus'),
+        ('16', 'Pacific'),
+        ('Dev', NULL);
+
+-- When grafana draws a graph with a resolution of a day, it expects the DB
+-- query to return a data point per day. A cluster may report less frequently
+-- than once a day, thus the DB query will return a spike on the day that
+-- the cluster reports, and a drop on days it doesn't.
+-- To normalize this, we create a materialized view that for each day holds
+-- a list of all reports that occurred on the previous week - only the most
+-- recent report for each cluster within that previous week.
+-- We use a materialized view because it's much faster than a regular view.
+-- We update the materialized view in import_clusters.py.
+CREATE MATERIALIZED VIEW grafana.weekly_reports_sliding AS
+    SELECT
+        DISTINCT ON(daily_window, cluster_id)
+        daily_window,
+        report_id
+        /*
+        GENERATE_SERIES generates a table with a single column 'daily_window'
+        which holds all the days (a row per day) between the first report
+        and today. Day format is 'YYYY-MM-DD 00:00:00'.
+        */
+    FROM
+        grafana.ts_cluster c,
+        GENERATE_SERIES('2019-03-01', now()::date, interval '1' day) daily_window
+    WHERE
+        c.ts BETWEEN daily_window - interval '7' day AND daily_window + interval '1' day
+    ORDER BY
+        daily_window,
+        cluster_id,
+        c.ts DESC;
+
+ALTER MATERIALIZED VIEW grafana.weekly_reports_sliding OWNER TO grafana;

--- a/db_create_dashboard.sql
+++ b/db_create_dashboard.sql
@@ -1,0 +1,1163 @@
+/*
+    Important:
+    These functions must be created by
+    'grafana' db user, so permissions are restricted.
+    These functions ('stored-procedures')
+    were created due to grafana's unrestricted
+    access to data sources.
+
+    The format of this file is the DDL of the function definition
+    followed by a comment with the query that is used in Grafana.
+*/
+
+
+------- DASHBOARD: TELEMETRY -------
+
+------- VARIABLE: major -------
+CREATE FUNCTION dashboard.version_to_name(
+    )
+    RETURNS SETOF grafana.version_to_name
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT *
+    FROM
+        grafana.version_to_name
+$$;
+
+/*
+-- Variable query:
+-- Creates 'Major' dropdown values
+SELECT
+    REPLACE(CONCAT(version, '  --  ', name), 'Dev  --  ', 'Dev')
+            AS __text,
+    version AS __value
+FROM
+    dashboard.version_to_name();
+*/
+
+------- VARIABLE: minor -------
+CREATE FUNCTION dashboard.minor_versions(
+        major TEXT[]
+    )
+    RETURNS SETOF TEXT
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        DISTINCT(value)
+    FROM
+        grafana.metadata
+    WHERE
+            attr='ceph_version_norm'
+        AND
+            SPLIT_PART(value, '.', '1') = ANY (major);
+$$;
+
+/*
+-- Variable query:
+-- Creates 'Minor' dropdown values
+SELECT *
+FROM
+    dashboard.minor_versions(ARRAY[$major]);
+*/
+
+------- PANEL OSD Count -------
+CREATE FUNCTION dashboard.osd_count()
+    RETURNS BIGINT
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        SUM(c.osd_count)
+	FROM
+        grafana.weekly_reports_sliding w
+	INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+	WHERE
+        daily_window = (SELECT MAX(daily_window) FROM grafana.weekly_reports_sliding);
+$$;
+
+/*
+-- Dashboard query:
+SELECT dashboard.osd_count();
+*/
+
+------- PANEL Active Clusters -------
+CREATE FUNCTION dashboard.active_clusters()
+    RETURNS BIGINT
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        COUNT(*) total
+    FROM
+        grafana.weekly_reports_sliding w
+    WHERE
+        daily_window = (SELECT MAX(daily_window) FROM grafana.weekly_reports_sliding);
+$$;
+
+/*
+-- Dashboard query:
+SELECT dashboard.active_clusters();
+*/
+
+------- PANEL TOTAL CAPACITY -------
+CREATE FUNCTION dashboard.total_capacity()
+    RETURNS NUMERIC
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        SUM(c.TOTAL_BYTES) total
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+    WHERE
+        daily_window = (SELECT MAX(daily_window) FROM grafana.weekly_reports_sliding);
+$$;
+
+/*
+-- Dashboard query:
+SELECT dashboard.total_capacity();
+*/
+
+------- PANEL Version by Cluster Count -------
+CREATE FUNCTION dashboard.version_by_cluster_count(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE,
+        display TEXT, -- 'Major' / 'Minor'
+        major TEXT[],
+        minor TEXT[],
+        daemons TEXT[]
+    )
+    RETURNS TABLE (
+		daily_window TIMESTAMP WITH TIME ZONE,
+		version TEXT,
+        total DOUBLE PRECISION
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    WITH
+    -- Get the matching metadata stats, per report
+    weekly_metadata AS (
+        SELECT
+            daily_window,
+            grafana.metadata.*
+        FROM
+            grafana.metadata
+        INNER JOIN
+            grafana.WEEKLY_REPORTS_SLIDING w
+        ON
+            w.report_id = grafana.metadata.report_id
+        WHERE
+            attr='ceph_version_norm'
+    ),
+    -- This retrieves total daemons per report (which is of a cluster, per week)
+    weekly_cluster_daemons AS (
+        SELECT
+            report_id,
+            SUM(total) sum_daemons
+        FROM
+            grafana.metadata
+        WHERE
+                attr='ceph_version_norm'
+            AND
+                entity = ANY (daemons)
+        GROUP BY
+            report_id
+    )
+    SELECT
+        daily_window,
+          -- This is basically wm.value
+          CASE WHEN display = 'Major'
+               THEN SPLIT_PART(value, '.', 1)
+               ELSE value
+          END AS metric,
+          SUM(wm.total / CAST(cd.sum_daemons AS REAL))
+    FROM
+        weekly_metadata wm
+    INNER JOIN
+        weekly_cluster_daemons cd
+    ON
+        wm.report_id = cd.report_id
+    WHERE
+        daily_window BETWEEN time_from AND time_to
+        AND
+            -- Include only values in retrieved Major / Minor array
+            CASE WHEN display='Major'
+                 THEN SPLIT_PART(value, '.', 1)
+                 ELSE value
+            END
+            = ANY (
+                    CASE WHEN display = 'Major'
+                         THEN major
+                         ELSE minor
+                    END
+                  )
+        AND
+            entity = ANY (daemons)
+    GROUP by
+        daily_window, 2
+    ORDER BY
+        2, daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    version AS metric,
+    total
+FROM
+	dashboard.version_by_cluster_count(
+        $__timeFrom(),
+        $__timeTo(),
+        -- display holds 'Major' / 'Minor';
+        -- Grafana adds single quotes only to array elements, and '$display' is a string,
+        -- so we add it manually here.
+        '$display',
+        ARRAY[$major],
+        ARRAY[$minor],
+        ARRAY[$daemons]
+    );
+*/
+
+------- PANEL Version by Daemon Count -------
+CREATE FUNCTION dashboard.version_by_daemon_count(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE,
+        display TEXT,
+        major TEXT[],
+        minor TEXT[],
+        daemons TEXT[]
+    )
+    RETURNS TABLE (
+		daily_window TIMESTAMP WITH TIME ZONE,
+		version TEXT,
+        total BIGINT
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        w.daily_window,
+        -- Do not change selection order, we group-by it.
+        -- value is metadata.value that holds the version
+        CASE
+            WHEN display = 'Major'
+            THEN SPLIT_PART(value, '.', 1)
+            ELSE value
+        END,
+        SUM(total)
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.metadata
+    ON
+        w.report_id = grafana.metadata.report_id
+    WHERE
+            attr='ceph_version_norm'
+        AND
+            w.daily_window BETWEEN time_from AND time_to
+        -- and value in ($major/$minor):
+        AND
+            CASE WHEN display = 'Major'
+                 THEN SPLIT_PART(value, '.', 1)
+                 ELSE value
+            END
+            = ANY (
+                    CASE WHEN display = 'Major'
+                         THEN major
+                         ELSE minor
+                    END
+                  )
+        AND
+            entity = ANY (daemons)
+    GROUP BY
+        w.daily_window, 2
+    ORDER BY
+        2, w.daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    version AS metric,
+    total
+FROM
+	dashboard.version_by_daemon_count(
+        $__timeFrom(),
+        $__timeTo(),
+        '$display', -- Holds 'Major' / 'Minor'
+        ARRAY[$major],
+        ARRAY[$minor],
+        ARRAY[$daemons]
+    );
+*/
+
+------- PANEL Active Clusters by a Daily Sliding Window of a Week -------
+CREATE FUNCTION dashboard.active_clusters_dsw(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+    RETURNS TABLE (
+		daily_window TIMESTAMP WITH TIME ZONE,
+		active_clusters BIGINT
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        daily_window AS time,
+        COUNT(*) AS "active_clusters"
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+    WHERE
+        daily_window BETWEEN time_from AND time_to
+    GROUP BY
+        daily_window
+    ORDER BY
+        daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+	daily_window AS time,
+	active_clusters AS "Active Clusters"
+FROM
+	dashboard.active_clusters_dsw($__timeFrom(), $__timeTo());
+*/
+
+------- PANEL OSD Count by a Daily Sliding Window of a Week -------
+CREATE FUNCTION dashboard.osd_count_dsw(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+    RETURNS TABLE (
+		daily_window TIMESTAMP WITH TIME ZONE,
+		sum_osd_count BIGINT
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        daily_window AS time,
+        SUM(c.osd_count) AS "sum_osd_count"
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+    WHERE
+        daily_window BETWEEN time_from AND time_to
+    GROUP BY
+        daily_window
+    ORDER BY
+        daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+	daily_window AS time,
+	sum_osd_count AS "OSD Count"
+FROM
+	dashboard.osd_count_dsw($__timeFrom(), $__timeTo());
+*/
+
+------- PANEL Total Capacity by a Daily Sliding Window of a Week -------
+CREATE FUNCTION dashboard.total_capacity_dsw(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+    RETURNS TABLE (
+		daily_window TIMESTAMP WITH TIME ZONE,
+		Total NUMERIC,
+		Used NUMERIC
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        daily_window AS time,
+        SUM(c.total_bytes) AS "Total",
+        SUM(c.total_used_bytes) AS "Used"
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+    WHERE
+        daily_window BETWEEN time_from AND time_to
+    GROUP BY
+        daily_window
+    ORDER BY
+        daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+	daily_window AS time,
+    Total AS "Total",
+    Used AS "Used"
+FROM
+	dashboard.total_capacity_dsw($__timeFrom(), $__timeTo());
+*/
+
+------- PANEL Cluster Distribution by Total Capacity -------
+CREATE FUNCTION dashboard.cluster_distribution_by_total_capacity(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+    RETURNS TABLE (
+		daily_window TIMESTAMP WITH TIME ZONE,
+		total_gb BIGINT
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        w.daily_window as time,
+        c.total_bytes / 1024 / 1024 / 1024 gb
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+    WHERE
+        w.daily_window BETWEEN time_from AND time_to
+    ORDER BY
+        w.daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+	daily_window AS time,
+	total_gb
+FROM
+	dashboard.cluster_distribution_by_total_capacity($__timeFrom(), $__timeTo());
+*/
+
+------- PANEL Cluster Distribution by Total Used Capacity -------
+CREATE FUNCTION dashboard.cluster_distribution_by_total_used_capacity(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+    RETURNS TABLE (
+		daily_window TIMESTAMP WITH TIME ZONE,
+		total_used_gb BIGINT
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        w.daily_window as time,
+        c.total_used_bytes / 1024 / 1024 / 1024 gb
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+    WHERE
+        w.daily_window BETWEEN time_from AND time_to
+    ORDER BY
+        w.daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+	daily_window AS time,
+	total_used_gb
+FROM
+	dashboard.cluster_distribution_by_total_used_capacity($__timeFrom(), $__timeTo());
+*/
+
+------- PANEL Cluster Distribution by OSD Count -------
+CREATE FUNCTION dashboard.cluster_distribution_by_osd_count(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+	RETURNS TABLE (
+		daily_window TIMESTAMP WITH TIME ZONE,
+		osd_count INT
+	)
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        w.daily_window,
+        c.osd_count
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+    WHERE
+        w.daily_window BETWEEN time_from AND time_to
+    ORDER BY
+        w.daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+	daily_window AS time,
+	osd_count
+FROM
+	dashboard.cluster_distribution_by_osd_count($__timeFrom(), $__timeTo());
+*/
+
+
+------- DASHBOARD: CAPACITY DENSITY -------
+
+------- PANEL Cluster / TiB - Capacity Percentiles by a Daily Sliding Window of a Week -------
+CREATE FUNCTION dashboard.cluster_tib_capacity_percentiles_dsw(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP WITH TIME ZONE,
+        p25 BIGINT,
+        p50 BIGINT,
+        p75 BIGINT,
+        p100 BIGINT
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        daily_window,
+        PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY c.total_bytes) AS p25,
+        PERCENTILE_DISC(0.50) WITHIN GROUP (ORDER BY c.total_bytes) AS p50,
+        PERCENTILE_DISC(0.75) WITHIN GROUP (ORDER BY c.total_bytes) AS p75,
+        PERCENTILE_DISC(1)    WITHIN GROUP (ORDER BY c.total_bytes) AS p100
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+    WHERE
+        daily_window BETWEEN time_from AND time_to
+    GROUP BY
+        daily_window
+    ORDER BY
+        daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    p25,
+    p50,
+    p75,
+    p100
+FROM
+    dashboard.cluster_tib_capacity_percentiles_dsw($__timeFrom()::DATE - INTERVAL '1' DAY, $__timeTo());
+
+-- Grafana expects consecutive data points, and since we have daily data points
+-- (single point per day), it sometimes shows the oldest point of the graph
+-- with zeros, rather than true values. We fix this by fetching results for one
+-- day before the actual selected time range (by casting to date and
+-- subtracting 1 day).
+*/
+
+------- PANEL Cluster / TiB < 1 PiB - Capacity Percentiles by a Daily Sliding Window of a Week -------
+CREATE FUNCTION dashboard.cluster_tib_lt_1_pib_capacity_percentiles_dsw(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP WITH TIME ZONE,
+        p25 BIGINT,
+        p50 BIGINT,
+        p75 BIGINT,
+        p100 BIGINT
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        daily_window,
+        PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY c.total_bytes) AS p25,
+        PERCENTILE_DISC(0.50) WITHIN GROUP (ORDER BY c.total_bytes) AS p50,
+        PERCENTILE_DISC(0.75) WITHIN GROUP (ORDER BY c.total_bytes) AS p75,
+        PERCENTILE_DISC(1)    WITHIN GROUP (ORDER BY c.total_bytes) AS p100
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+    WHERE
+            c.total_bytes / 1024 / 1024 / 1024 / 1024 / 1024::REAL < 1
+        AND
+            daily_window BETWEEN time_from AND time_to
+    GROUP BY
+        daily_window
+    ORDER BY
+        daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    p25,
+    p50,
+    p75,
+    p100
+FROM
+    dashboard.cluster_tib_lt_1_pib_capacity_percentiles_dsw($__timeFrom()::DATE - INTERVAL '1' DAY, $__timeTo());
+*/
+
+------- PANEL Cluster / TiB > 1 PiB - Capacity Percentiles by a Daily Sliding Window of a Week -------
+CREATE FUNCTION dashboard.cluster_tib_gt_1_pib_capacity_percentiles_dsw(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP WITH TIME ZONE,
+        p25 BIGINT,
+        p50 BIGINT,
+        p75 BIGINT,
+        p100 BIGINT
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        daily_window,
+        PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY c.total_bytes) AS p25,
+        PERCENTILE_DISC(0.50) WITHIN GROUP (ORDER BY c.total_bytes) AS p50,
+        PERCENTILE_DISC(0.75) WITHIN GROUP (ORDER BY c.total_bytes) AS p75,
+        PERCENTILE_DISC(1)    WITHIN GROUP (ORDER BY c.total_bytes) AS p100
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+    WHERE
+            c.total_bytes / 1024 / 1024 / 1024 / 1024 / 1024::REAL > 1
+        AND
+            daily_window BETWEEN time_from AND time_to
+    GROUP BY
+        daily_window
+    ORDER BY
+        daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    p25,
+    p50,
+    p75,
+    p100
+FROM
+    dashboard.cluster_tib_gt_1_pib_capacity_percentiles_dsw($__timeFrom()::DATE - INTERVAL '1' DAY, $__timeTo());
+*/
+
+------- PANEL OSD / Host - Capacity per Hosts Percentiles by a Daily Sliding Window of a Week -------
+CREATE FUNCTION dashboard.osd_host_capacity_per_hosts_percentiles_dsw(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP WITH TIME ZONE,
+        p25  DOUBLE PRECISION,
+        p50  DOUBLE PRECISION,
+        p75  DOUBLE PRECISION,
+        p100 DOUBLE PRECISION
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        daily_window,
+        PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY c.osd_count / c.hosts_num::REAL) AS p25,
+        PERCENTILE_DISC(0.50) WITHIN GROUP (ORDER BY c.osd_count / c.hosts_num::REAL) AS p50,
+        PERCENTILE_DISC(0.75) WITHIN GROUP (ORDER BY c.osd_count / c.hosts_num::REAL) AS p75,
+        PERCENTILE_DISC(1)    WITHIN GROUP (ORDER BY c.osd_count / c.hosts_num::REAL) AS p100
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+    WHERE
+        daily_window BETWEEN time_from AND time_to
+    GROUP BY
+        daily_window
+    ORDER BY
+        daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    p25,
+    p50,
+    p75,
+    p100
+FROM
+    dashboard.osd_host_capacity_per_hosts_percentiles_dsw($__timeFrom()::DATE - INTERVAL '1' DAY, $__timeTo());
+*/
+
+------- PANEL OSD / Host < 1 PiB - Capacity per Hosts Percentiles by a Daily Sliding Window of a Week -------
+CREATE FUNCTION dashboard.osd_host_lt_1_pib_capacity_per_hosts_percentiles_dsw(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP WITH TIME ZONE,
+        p25  DOUBLE PRECISION,
+        p50  DOUBLE PRECISION,
+        p75  DOUBLE PRECISION,
+        p100 DOUBLE PRECISION
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        daily_window,
+        PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY c.osd_count / c.hosts_num::REAL) AS p25,
+        PERCENTILE_DISC(0.50) WITHIN GROUP (ORDER BY c.osd_count / c.hosts_num::REAL) AS p50,
+        PERCENTILE_DISC(0.75) WITHIN GROUP (ORDER BY c.osd_count / c.hosts_num::REAL) AS p75,
+        PERCENTILE_DISC(1)    WITHIN GROUP (ORDER BY c.osd_count / c.hosts_num::REAL) AS p100
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+    WHERE
+            c.total_bytes / 1024 / 1024 / 1024 / 1024 / 1024::REAL < 1
+        AND
+            daily_window BETWEEN time_from AND time_to
+    GROUP BY
+        daily_window
+    ORDER BY
+        daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    p25,
+    p50,
+    p75,
+    p100
+FROM
+    dashboard.osd_host_lt_1_pib_capacity_per_hosts_percentiles_dsw($__timeFrom()::DATE - INTERVAL '1' DAY, $__timeTo());
+*/
+
+------- PANEL OSD / Host > 1 PiB - Capacity per Hosts Percentiles by a Daily Sliding Window of a Week -------
+CREATE FUNCTION dashboard.osd_host_gt_1_pib_capacity_per_hosts_percentiles_dsw(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP WITH TIME ZONE,
+        p25  DOUBLE PRECISION,
+        p50  DOUBLE PRECISION,
+        p75  DOUBLE PRECISION,
+        p100 DOUBLE PRECISION
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        daily_window,
+        PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY c.osd_count / c.hosts_num::REAL) AS p25,
+        PERCENTILE_DISC(0.50) WITHIN GROUP (ORDER BY c.osd_count / c.hosts_num::REAL) AS p50,
+        PERCENTILE_DISC(0.75) WITHIN GROUP (ORDER BY c.osd_count / c.hosts_num::REAL) AS p75,
+        PERCENTILE_DISC(1)    WITHIN GROUP (ORDER BY c.osd_count / c.hosts_num::REAL) AS p100
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+    WHERE
+            c.total_bytes / 1024 / 1024 / 1024 / 1024 / 1024::REAL > 1
+        AND
+            daily_window BETWEEN time_from AND time_to
+    GROUP BY
+        daily_window
+    ORDER BY
+        daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    p25,
+    p50,
+    p75,
+    p100
+FROM
+    dashboard.osd_host_gt_1_pib_capacity_per_hosts_percentiles_dsw($__timeFrom()::DATE - INTERVAL '1' DAY, $__timeTo());
+*/
+
+------- PANEL TiB / OSD - Capacity per OSD Count Percentiles by a Daily Sliding Window of a Week -------
+CREATE FUNCTION dashboard.tib_osd_capacity_per_osd_count_percentiles_dsw(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP WITH TIME ZONE,
+        p25  DOUBLE PRECISION,
+        p50  DOUBLE PRECISION,
+        p75  DOUBLE PRECISION,
+        p100 DOUBLE PRECISION
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        daily_window,
+        PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY c.total_bytes / c.osd_count::REAL) AS p25,
+        PERCENTILE_DISC(0.50) WITHIN GROUP (ORDER BY c.total_bytes / c.osd_count::REAL) AS p50,
+        PERCENTILE_DISC(0.75) WITHIN GROUP (ORDER BY c.total_bytes / c.osd_count::REAL) AS p75,
+        PERCENTILE_DISC(1)    WITHIN GROUP (ORDER BY c.total_bytes / c.osd_count::REAL) AS p100
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+    WHERE
+            c.osd_count > 0
+        AND
+            daily_window BETWEEN time_from AND time_to
+    GROUP BY
+        daily_window
+    ORDER BY
+        daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    p25,
+    p50,
+    p75,
+    p100
+FROM
+    dashboard.tib_osd_capacity_per_osd_count_percentiles_dsw($__timeFrom()::DATE - INTERVAL '1' DAY, $__timeTo());
+*/
+
+------- PANEL TiB / OSD < 1 PiB - Capacity per OSD Count Percentiles by a Daily Sliding Window of a Week -------
+CREATE FUNCTION dashboard.tib_osd_lt_1_pib_capacity_per_osd_count_percentiles_dsw(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP WITH TIME ZONE,
+        p25  DOUBLE PRECISION,
+        p50  DOUBLE PRECISION,
+        p75  DOUBLE PRECISION,
+        p100 DOUBLE PRECISION
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        daily_window,
+        PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY c.total_bytes / c.osd_count::REAL) AS p25,
+        PERCENTILE_DISC(0.50) WITHIN GROUP (ORDER BY c.total_bytes / c.osd_count::REAL) AS p50,
+        PERCENTILE_DISC(0.75) WITHIN GROUP (ORDER BY c.total_bytes / c.osd_count::REAL) AS p75,
+        PERCENTILE_DISC(1)    WITHIN GROUP (ORDER BY c.total_bytes / c.osd_count::REAL) AS p100
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+    WHERE
+            c.osd_count > 0
+        AND
+            c.total_bytes / 1024 / 1024 / 1024 / 1024 / 1024::REAL < 1
+        AND
+            daily_window BETWEEN time_from AND time_to
+    GROUP BY
+        daily_window
+    ORDER BY
+        daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    p25,
+    p50,
+    p75,
+    p100
+FROM
+    dashboard.tib_osd_lt_1_pib_capacity_per_osd_count_percentiles_dsw($__timeFrom()::DATE - INTERVAL '1' DAY, $__timeTo());
+*/
+
+------- PANEL TiB / OSD > 1 PiB - Capacity per OSD Count Percentiles by a Daily Sliding Window of a Week -------
+CREATE FUNCTION dashboard.tib_osd_gt_1_pib_capacity_per_osd_count_percentiles_dsw(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP WITH TIME ZONE,
+        p25  DOUBLE PRECISION,
+        p50  DOUBLE PRECISION,
+        p75  DOUBLE PRECISION,
+        p100 DOUBLE PRECISION
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        daily_window,
+        PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY c.total_bytes / c.osd_count::REAL) AS p25,
+        PERCENTILE_DISC(0.50) WITHIN GROUP (ORDER BY c.total_bytes / c.osd_count::REAL) AS p50,
+        PERCENTILE_DISC(0.75) WITHIN GROUP (ORDER BY c.total_bytes / c.osd_count::REAL) AS p75,
+        PERCENTILE_DISC(1)    WITHIN GROUP (ORDER BY c.total_bytes / c.osd_count::REAL) AS p100
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+    WHERE
+            c.osd_count > 0
+        AND
+            c.total_bytes / 1024 / 1024 / 1024 / 1024 / 1024::REAL > 1
+        AND
+            daily_window BETWEEN time_from AND time_to
+    GROUP BY
+        daily_window
+    ORDER BY
+        daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    p25,
+    p50,
+    p75,
+    p100
+FROM
+    dashboard.tib_osd_gt_1_pib_capacity_per_osd_count_percentiles_dsw($__timeFrom()::DATE - INTERVAL '1' DAY, $__timeTo());
+*/
+
+------- PANEL TiB / Host - Capacity per Hosts Percentiles by a Daily Sliding Window of a Week -------
+CREATE FUNCTION dashboard.tib_host_capacity_per_hosts_percentiles_dsw(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP WITH TIME ZONE,
+        p25  DOUBLE PRECISION,
+        p50  DOUBLE PRECISION,
+        p75  DOUBLE PRECISION,
+        p100 DOUBLE PRECISION
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        daily_window,
+        PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY c.total_bytes / c.hosts_num::REAL) AS p25,
+        PERCENTILE_DISC(0.50) WITHIN GROUP (ORDER BY c.total_bytes / c.hosts_num::REAL) AS p50,
+        PERCENTILE_DISC(0.75) WITHIN GROUP (ORDER BY c.total_bytes / c.hosts_num::REAL) AS p75,
+        PERCENTILE_DISC(1)    WITHIN GROUP (ORDER BY c.total_bytes / c.hosts_num::REAL) AS p100
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+    WHERE
+        daily_window BETWEEN time_from AND time_to
+    GROUP BY
+        daily_window
+    ORDER BY
+        daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    p25,
+    p50,
+    p75,
+    p100
+FROM
+    dashboard.tib_host_capacity_per_hosts_percentiles_dsw($__timeFrom()::DATE - INTERVAL '1' DAY, $__timeTo());
+*/
+
+------- PANEL TiB / Host < 1 PiB - Capacity per Hosts Percentiles by a Daily Sliding Window of a Week -------
+CREATE FUNCTION dashboard.tib_host_lt_1_pib_capacity_per_hosts_percentiles_dsw(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP WITH TIME ZONE,
+        p25  DOUBLE PRECISION,
+        p50  DOUBLE PRECISION,
+        p75  DOUBLE PRECISION,
+        p100 DOUBLE PRECISION
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        daily_window,
+        PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY c.total_bytes / c.hosts_num::REAL) AS p25,
+        PERCENTILE_DISC(0.50) WITHIN GROUP (ORDER BY c.total_bytes / c.hosts_num::REAL) AS p50,
+        PERCENTILE_DISC(0.75) WITHIN GROUP (ORDER BY c.total_bytes / c.hosts_num::REAL) AS p75,
+        PERCENTILE_DISC(1)    WITHIN GROUP (ORDER BY c.total_bytes / c.hosts_num::REAL) AS p100
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+    WHERE
+            c.total_bytes / 1024 / 1024 / 1024 / 1024 / 1024::REAL < 1
+        AND
+            daily_window BETWEEN time_from AND time_to
+    GROUP BY
+        daily_window
+    ORDER BY
+        daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    p25,
+    p50,
+    p75,
+    p100
+FROM
+    dashboard.tib_host_lt_1_pib_capacity_per_hosts_percentiles_dsw($__timeFrom()::DATE - INTERVAL '1' DAY, $__timeTo());
+*/
+
+------- PANEL TiB / Host > 1 PiB - Capacity per Hosts Percentiles by a Daily Sliding Window of a Week -------
+CREATE FUNCTION dashboard.tib_host_gt_1_pib_capacity_per_hosts_percentiles_dsw(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP WITH TIME ZONE,
+        p25  DOUBLE PRECISION,
+        p50  DOUBLE PRECISION,
+        p75  DOUBLE PRECISION,
+        p100 DOUBLE PRECISION
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        daily_window,
+        PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY c.total_bytes / c.hosts_num::REAL) AS p25,
+        PERCENTILE_DISC(0.50) WITHIN GROUP (ORDER BY c.total_bytes / c.hosts_num::REAL) AS p50,
+        PERCENTILE_DISC(0.75) WITHIN GROUP (ORDER BY c.total_bytes / c.hosts_num::REAL) AS p75,
+        PERCENTILE_DISC(1)    WITHIN GROUP (ORDER BY c.total_bytes / c.hosts_num::REAL) AS p100
+    FROM
+        grafana.weekly_reports_sliding w
+    INNER JOIN
+        grafana.ts_cluster c
+    ON
+        w.report_id = c.report_id
+    WHERE
+            c.total_bytes / 1024 / 1024 / 1024 / 1024 / 1024::REAL > 1
+        AND
+            daily_window BETWEEN time_from AND time_to
+    GROUP BY
+        daily_window
+    ORDER BY
+        daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    p25,
+    p50,
+    p75,
+    p100
+FROM
+    dashboard.tib_host_gt_1_pib_capacity_per_hosts_percentiles_dsw($__timeFrom()::DATE - INTERVAL '1' DAY, $__timeTo());
+*/
+
+
+------- DASHBOARD: X-ray -------
+
+------- PANEL Cluster ID -------
+CREATE FUNCTION dashboard.get_cluster_id(uuid TEXT)
+    RETURNS TEXT
+LANGUAGE plpgsql SECURITY DEFINER
+AS $BODY$
+DECLARE
+    cluster_id_res TEXT := NULL;
+BEGIN
+	IF uuid IS NULL OR uuid = ''
+	THEN
+	    RETURN
+            '<span>Please enter your cluster ID.'
+            '<br><br>You can find it with:&nbsp;&nbsp;''ceph telemetry show | grep report_id''</span>';
+	ELSE
+		SELECT cluster_id INTO cluster_id_res
+			FROM grafana.ts_cluster
+			WHERE cluster_id = uuid
+			LIMIT 1;
+		IF cluster_id_res IS NOT NULL
+		THEN
+			RETURN uuid;
+		ELSE
+	        RETURN 'Invalid cluster ID.';
+		END IF;
+	END IF;
+END;
+$BODY$;
+
+/*
+-- Dashboard query:
+SELECT dashboard.get_cluster_id('$c_id');
+*/
+
+------- PANEL - General query for x-ray panel -------
+-- This query was generalized to work
+-- with all of cluster x-ray panels.
+-- It's okay because 'uuid' cannot be guessed.
+CREATE FUNCTION dashboard.get_ts_cluster(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE,
+        uuid TEXT
+)
+    RETURNS SETOF grafana.ts_cluster
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT *
+    FROM
+        grafana.ts_cluster c
+    WHERE
+            c.cluster_id = uuid
+        AND
+            c.ts BETWEEN time_from AND time_to
+$$;
+
+/*
+-- Dashboard query:
+SELECT *
+FROM
+    dashboard.get_ts_cluster($__timeFrom(), $__timeTo(), '$c_id');
+*/

--- a/db_create_roles.sql
+++ b/db_create_roles.sql
@@ -1,0 +1,58 @@
+
+--CREATE USER grafana WITH PASSWORD '<PASSWORD>';
+--CREATE USER grafana_ro WITH PASSWORD '<PASSWORD>';
+GRANT USAGE ON SCHEMA grafana TO grafana, grafana_ro;
+GRANT ALL ON ALL TABLES IN SCHEMA grafana TO grafana; -- "ALL TABLES" includes views
+GRANT ALL ON ALL SEQUENCES IN SCHEMA grafana TO grafana;
+GRANT SELECT ON TABLE public.report, public.device_report, public.crash TO grafana;
+
+-- Grant access to grafana on future tables & seq in schema grafana
+ALTER DEFAULT PRIVILEGES
+    FOR ROLE postgres
+    IN SCHEMA grafana
+    GRANT ALL ON TABLES TO grafana;
+
+ALTER DEFAULT PRIVILEGES
+    FOR ROLE postgres
+    IN SCHEMA grafana
+    GRANT ALL ON SEQUENCES TO grafana;
+
+GRANT SELECT ON ALL TABLES IN SCHEMA grafana TO grafana_ro;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA grafana TO grafana_ro;
+GRANT SELECT ON TABLE public.report, public.device_report, public.crash TO grafana_ro;
+
+ALTER DEFAULT PRIVILEGES
+    FOR ROLE postgres
+    IN SCHEMA grafana
+    GRANT SELECT ON TABLES TO grafana_ro;
+
+ALTER DEFAULT PRIVILEGES
+    FOR ROLE postgres
+    IN SCHEMA grafana
+    GRANT SELECT ON SEQUENCES TO grafana_ro;
+
+--CREATE USER dashboard WITH PASSWORD '<PASSWORD>' NOINHERIT;
+CREATE SCHEMA IF NOT EXISTS dashboard;
+
+GRANT USAGE ON SCHEMA dashboard TO dashboard, grafana, grafana_ro;
+GRANT CREATE ON SCHEMA dashboard TO grafana;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA dashboard TO dashboard, grafana_ro;
+
+ALTER DEFAULT PRIVILEGES
+    FOR ROLE grafana
+    IN SCHEMA dashboard
+    GRANT EXECUTE ON FUNCTIONS TO dashboard;
+
+GRANT ALL ON ALL TABLES IN SCHEMA dashboard TO grafana;
+
+-- Revoking 'CREATE' permissions from
+-- PUBLIC read-only users on 'public' schema:
+GRANT CONNECT ON DATABASE telemetry TO postgres, telemetry, grafana, grafana_ro, dashboard;
+GRANT CONNECT ON DATABASE postgres TO postgres, telemetry;
+GRANT USAGE ON SCHEMA public TO postgres, telemetry, grafana, grafana_ro;
+GRANT CREATE ON SCHEMA public TO postgres, telemetry;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public to postgres, telemetry;
+GRANT USAGE ON LANGUAGE SQL to postgres, telemetry;
+REVOKE ALL ON SCHEMA public FROM PUBLIC;
+REVOKE CONNECT, TEMPORARY ON DATABASE telemetry FROM PUBLIC;
+REVOKE CONNECT ON DATABASE postgres FROM PUBLIC;

--- a/dbhelper.py
+++ b/dbhelper.py
@@ -1,0 +1,18 @@
+#! /usr/bin/env python3
+# vim: ts=4 sw=4 expandtab
+
+import psycopg2
+from psycopg2.extensions import AsIs
+import os
+import json
+from os.path import isfile, join
+
+
+def run_insert(cur, sql, d, extra_vals = None):
+    columns = d.keys()
+    values = [d[column] for column in columns]
+
+    if extra_vals is None:
+        extra_vals = ()
+    cur.execute(sql, (AsIs(','.join(columns)), tuple(values)) + extra_vals)
+    #print(cur.mogrify(sql, (AsIs(','.join(columns)), tuple(values))))

--- a/import_clusters.py
+++ b/import_clusters.py
@@ -1,0 +1,153 @@
+#! /usr/bin/env python3
+# vim: ts=4 sw=4 expandtab
+
+import dbhelper
+import psycopg2
+import psycopg2.extras
+import json
+import re
+import sys
+from pathlib import Path
+from os import listdir
+from os.path import isfile, join
+import time
+
+# Data Source Name file
+DSN = '/opt/telemetry/grafana.dsn'
+
+# 'j' stands for report_json
+def insert_into_all_tables(conn, report_id_serial, j):
+    cur = conn.cursor()
+    report_timestamp = j.get('report_timestamp')
+
+    cluster = {}
+    cluster['report_id']            = report_id_serial
+    cluster['cluster_id']           = j.get('report_id')
+    # If a field does not exist in the json then it will be inserted as "null" to the database
+    cluster['ts']                   = report_timestamp
+    cluster['created']              = j.get('created')
+    if cluster['created'] == '0.000000':
+        print("Weird created value for cluster. Skipping\n")
+        return
+    cluster['channel_basic']        = 'basic' in j.get('channels', [])
+    cluster['channel_crash']        = 'crash' in j.get('channels', [])
+    cluster['channel_device']       = 'device' in j.get('channels', [])
+    cluster['channel_ident']        = 'ident' in j.get('channels', [])
+
+    cluster['total_bytes']          = j.get('usage', {}).get('total_bytes')
+    cluster['total_used_bytes']     = j.get('usage', {}).get('total_used_bytes')
+
+    cluster['osd_count']            = j.get('osd', {}).get('count')
+    cluster['mon_count']            = j.get('mon', {}).get('count')
+    cluster['ipv4_addr_mons']       = j.get('mon', {}).get('ipv4_addr_mons')
+    cluster['ipv6_addr_mons']       = j.get('mon', {}).get('ipv6_addr_mons')
+    cluster['v1_addr_mons']         = j.get('mon', {}).get('v1_addr_mons')
+    cluster['v2_addr_mons']         = j.get('mon', {}).get('v2_addr_mons')
+
+    cluster['rbd_num_pools']        = j.get('rbd', {}).get('num_pools')
+
+    cluster['fs_count']             = j.get('fs', {}).get('count')
+    cluster['hosts_num']            = j.get('hosts', {}).get('num')
+    cluster['pools_num']            = j.get('usage', {}).get('pools')
+    # Compatibility with older telemetry modules
+    cluster['pg_num']               = j.get('usage', {}).get('pg_num') or j.get('usage', {}).get('pg_num:')
+
+    sql = 'INSERT INTO grafana.ts_cluster (%s) VALUES %s'
+    dbhelper.run_insert(cur, sql, cluster)
+
+    for p in j.get('pools', []):
+        pool = {}
+        pool['ts']                      = report_timestamp
+        pool['report_id']               = report_id_serial
+        pool['pool_idx']                = p.get('pool')
+        pool['pgp_num']                 = p.get('pgp_num')
+        pool['pg_num']                  = p.get('pg_num')
+        pool['size']                    = p.get('size')
+        pool['min_size']                = p.get('min_size')
+        pool['cache_mode']              = p.get('cache_mode')
+        pool['target_max_objects']      = p.get('target_max_objects')
+        pool['target_max_bytes']        = p.get('target_max_bytes')
+        pool['pg_autoscale_mode']       = p.get('pg_autoscale_mode')
+        pool['type']                    = p.get('type')
+        pool['ec_k']                    = p.get('erasure_code_profile', {}).get('k')
+        pool['ec_m']                    = p.get('erasure_code_profile', {}).get('m')
+        pool['ec_crush_failure_domain'] = p.get('erasure_code_profile', {}).get('crush_failure_domain')
+        pool['ec_plugin']               = p.get('erasure_code_profile', {}).get('plugin')
+        pool['ec_technique']            = p.get('erasure_code_profile', {}).get('technique')
+
+        sql = 'INSERT INTO grafana.pool (%s) VALUES %s'
+        dbhelper.run_insert(cur, sql, pool)
+
+    for entity, entity_val in j.get('metadata', {}).items():
+        for attr, attr_val in entity_val.items():
+            for value, total in attr_val.items():
+                metadata = {}
+                metadata['ts']          = report_timestamp
+                metadata['report_id']   = report_id_serial
+                metadata['entity']      = entity
+                metadata['attr']        = attr
+                metadata['value']       = value
+                metadata['total']       = total
+
+                sql = 'INSERT INTO grafana.metadata (%s) VALUES %s'
+                dbhelper.run_insert(cur, sql, metadata)
+                # Adding a normalized 'ceph_version' record
+                # to 'metadata' table by extracting the numeric version part
+                if attr == 'ceph_version':
+                    metadata['attr'] = 'ceph_version_norm'
+                    metadata['value'] = re.match('ceph version v*([0-9.]+|Dev).*', value).group(1)
+                    dbhelper.run_insert(cur, sql, metadata)
+
+    for i in range(j.get('rbd', {}).get('num_pools', 0)):
+        rbd_pool = {}
+        rbd_pool['ts']          = report_timestamp
+        rbd_pool['report_id']   = report_id_serial
+        rbd_pool['pool_idx']    = i # This index is internal in the db
+        rbd_pool['num_images']  = j['rbd']['num_images_by_pool'][i] # FIXME Will crash in case key is missing
+        rbd_pool['mirroring']   = j['rbd']['mirroring_by_pool'][i]
+
+        sql = 'INSERT INTO grafana.rbd_pool (%s) VALUES %s'
+        dbhelper.run_insert(cur, sql, rbd_pool)
+
+    # Commiting once, so everything is one transaction
+    conn.commit()
+
+def main():
+    start_time = time.time()
+    with open(DSN, 'r') as f:
+        dsn_str = f.read().strip()
+
+    conn = psycopg2.connect(dsn_str)
+    # Create a named server-side cursor
+    dict_cur = conn.cursor(name='server_side_cursor', withhold=True, cursor_factory=psycopg2.extras.DictCursor)
+    dict_cur.itersize = 10
+    # Fetch only reports which are not already in ts_cluster;
+    # COALESCE returns the first non-NULL value, so '0' is
+    # the returned id in case ts_cluster table is empty.
+    dict_cur.execute("""SELECT id, report
+                        FROM public.report
+                        WHERE id > (SELECT COALESCE(MAX(ts_cluster.report_id), 0)
+                                    FROM grafana.ts_cluster)
+                        ORDER BY id""")
+    cnt = 0
+    try:
+        for r in dict_cur:
+            cnt += 1
+            insert_into_all_tables(conn, r['id'], json.loads(r['report']))
+        dict_cur.close()
+    except:
+        print(f"Exception when processing public.report.id={r['id']}\n")
+        conn.rollback()
+        raise
+    finally:
+        refresh_cur = conn.cursor()
+        refresh_cur.execute("REFRESH MATERIALIZED VIEW grafana.weekly_reports_sliding")
+        conn.commit()
+        refresh_cur.close()
+
+    end_time = time.time()
+    time_delta = int(end_time - start_time)
+    print(f"Processed {cnt} reports in {time_delta} seconds\n")
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
added:
- roles permission definitions.
- 'grafana' schema and its time series cluster tables definitions.
- script to populate grafana's schema tables. 
- 'dashboard' schema to be used by 'dashboard' read-only db user. This
  schema contains only stored procedures, and was created in order to
  handle the unrestricted access to data sources from Grafana dashboard
  itself.

Signed-off-by: Yaarit Hatuka <yaarit@redhat.com>