### PR TITLE
add Postgres and Grafana logic for devices

### DIFF
--- a/db_create_dashboard_device.sql
+++ b/db_create_dashboard_device.sql
@@ -1,0 +1,884 @@
+/*
+Important:
+These functions must be created by 'grafana' db user, so permissions are
+restricted.
+
+These functions ('stored-procedures') were created due to Grafana's
+unrestricted access to data sources.
+
+The structure of this file is the DDL of the function's definition,
+followed by a comment with the query that is used in Grafana.
+
+In order to prevent ambiguity in variable substitution in the functions
+below, always prefix variable names with 'v_', assuming there is no column
+mentioned in the function which also starts with 'v_'.
+
+While debugging pay attention that Postgres supports function overloading and
+the function that is called may not be the one you expected.
+*/
+
+------- DASHBOARD: Devices / Main -------
+
+------- VARIABLE: class -------
+CREATE OR REPLACE FUNCTION dashboard_device.get_class(
+    )
+    RETURNS SETOF device.class
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        DISTINCT(class)
+    FROM
+        device.spec
+    WHERE
+        device.spec.class != 'unknown';
+$$;
+
+/*
+-- Variable query:
+-- Creates 'class' dropdown values
+SELECT dashboard_device.get_class()
+*/
+
+------- VARIABLE: vendor -------
+CREATE OR REPLACE FUNCTION dashboard_device.get_vendors(
+        v_class TEXT[]
+    )
+    RETURNS SETOF TEXT
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        DISTINCT(vendor)
+    FROM
+        device.spec
+    WHERE
+        device.spec.class = ANY (v_class::device.class[]);
+$$;
+
+/*
+-- Variable query:
+-- Creates 'vendor' dropdown values
+SELECT dashboard_device.get_vendors(ARRAY[$class]);
+*/
+
+------- VARIABLE: model -------
+CREATE OR REPLACE FUNCTION dashboard_device.get_models(
+        v_vendor TEXT[]
+    )
+    RETURNS SETOF TEXT
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        DISTINCT(model)
+    FROM
+        device.spec
+    WHERE
+        device.spec.vendor = ANY (v_vendor);
+$$;
+
+/*
+-- Variable query:
+-- Creates 'model' dropdown values
+SELECT dashboard_device.get_models(ARRAY[$vendor]);
+*/
+
+------- PANEL Active Devices -------
+CREATE OR REPLACE FUNCTION dashboard_device.active_devices(
+        v_class TEXT[],
+        v_vendor TEXT[],
+        v_model TEXT[]
+)
+    RETURNS BIGINT
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        COUNT(*) total
+    FROM
+        device.weekly_reports_sliding w
+        INNER JOIN device.ts_device ON w.report_id = device.ts_device.report_id
+        INNER JOIN device.device ON device.ts_device.DEVICE_ID = device.device.id
+        INNER JOIN device.spec ON device.device.SPEC_ID = device.spec.id
+    WHERE
+        daily_window = (SELECT MAX(daily_window) FROM device.weekly_reports_sliding)
+        AND device.spec.class = ANY (v_class::device.class[])
+        AND device.spec.vendor = ANY (v_vendor)
+        AND device.spec.model = ANY (v_model);
+$$;
+
+/*
+-- Dashboard query:
+SELECT dashboard_device.active_devices(ARRAY[$class], ARRAY[$vendor], ARRAY[$model]);
+*/
+
+------- PANEL With Valid Telemetry -------
+CREATE OR REPLACE FUNCTION dashboard_device.with_valid_telemetry(
+        v_class TEXT[],
+        v_vendor TEXT[],
+        v_model TEXT[]
+)
+    RETURNS BIGINT
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        COUNT(*) total
+    FROM
+        device.weekly_reports_sliding w
+        INNER JOIN device.ts_device ON w.report_id = device.ts_device.report_id
+        INNER JOIN device.device ON device.ts_device.DEVICE_ID = device.device.id
+        INNER JOIN device.spec ON device.device.SPEC_ID = device.spec.id
+    WHERE
+        daily_window = (SELECT MAX(daily_window) FROM device.weekly_reports_sliding)
+        AND device.ts_device.error IS NULL -- meaning there's data in the report
+        AND device.spec.class = ANY (v_class::device.class[]) -- note the enum casting
+        AND device.spec.vendor = ANY (v_vendor)
+        AND device.spec.model = ANY (v_model);
+$$;
+
+/*
+-- Dashboard query:
+SELECT dashboard_device.with_valid_telemetry(ARRAY[$class], ARRAY[$vendor], ARRAY[$model]);
+*/
+
+------- PANEL Total Capacity -------
+CREATE OR REPLACE FUNCTION dashboard_device.total_capacity(
+        v_class TEXT[],
+        v_vendor TEXT[],
+        v_model TEXT[]
+)
+    RETURNS NUMERIC
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        SUM(capacity)
+    FROM
+        device.weekly_reports_sliding w
+		INNER JOIN device.ts_device ON w.report_id = device.ts_device.report_id
+		INNER JOIN device.device ON device.ts_device.DEVICE_ID = device.device.id
+		INNER JOIN device.spec ON device.device.SPEC_ID = device.spec.id
+    WHERE
+        daily_window = (SELECT MAX(daily_window) FROM device.weekly_reports_sliding)
+        AND device.spec.class = ANY (v_class::device.class[])
+        AND device.spec.vendor = ANY (v_vendor)
+        AND device.spec.model = ANY (v_model);
+$$;
+
+/*
+-- Dashboard query:
+SELECT dashboard_device.total_capacity(ARRAY[$class], ARRAY[$vendor], ARRAY[$model]);
+*/
+
+------- PANEL Hosts - All-time -------
+CREATE OR REPLACE FUNCTION dashboard_device.hosts_all_time(
+        v_class TEXT[],
+        v_vendor TEXT[]
+)
+    RETURNS BIGINT
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        COUNT(DISTINCT(host_id))
+    FROM
+        device.device d
+    INNER JOIN device.spec s ON d.spec_id = s.id
+    WHERE
+        s.class = ANY (v_class::device.class[])
+        AND s.vendor = ANY (v_vendor);
+$$;
+
+/*
+-- Dashboard query:
+SELECT dashboard_device.hosts_all_time(ARRAY[$class], ARRAY[$vendor]);
+*/
+
+------- PANEL Vendors - All-time -------
+CREATE OR REPLACE FUNCTION dashboard_device.vendors_all_time(
+        v_class TEXT[]
+)
+    RETURNS BIGINT
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        COUNT(DISTINCT(vendor))
+    FROM
+        device.spec
+    WHERE
+        device.spec.class = ANY (v_class::device.class[]);
+$$;
+
+
+/*
+-- Dashboard query:
+SELECT dashboard_device.vendors_all_time(ARRAY[$class]);
+*/
+
+------- PANEL Models - All-time -------
+CREATE OR REPLACE FUNCTION dashboard_device.models_all_time(
+        v_class TEXT[],
+        v_vendor TEXT[]
+)
+    RETURNS BIGINT
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        COUNT(DISTINCT(model))
+    FROM
+        device.spec
+    WHERE
+        device.spec.class = ANY (v_class::device.class[])
+        AND device.spec.vendor = ANY (v_vendor);
+$$;
+
+/*
+-- Dashboard query:
+SELECT dashboard_device.models_all_time(ARRAY[$class], ARRAY[$vendor]);
+*/
+
+------- PANEL Devices by Vendors -------
+CREATE OR REPLACE FUNCTION dashboard_device.devices_by_vendors(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE,
+        v_class TEXT[],
+        v_vendor TEXT[],
+        v_model TEXT[]
+)
+    RETURNS TABLE (
+        daily_window TIMESTAMP,
+        vendor TEXT,
+        total BIGINT
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        w.daily_window,
+        device.spec.vendor,
+        COUNT(*)
+    FROM
+        device.weekly_reports_sliding w
+        INNER JOIN device.ts_device ON w.report_id = device.ts_device.report_id
+        INNER JOIN device.device ON device.ts_device.DEVICE_ID = device.device.id
+        INNER JOIN device.spec ON device.device.SPEC_ID = device.spec.id
+    WHERE
+        w.daily_window BETWEEN time_from AND time_to
+      AND device.spec.class = ANY (v_class::device.class[])
+      AND device.spec.vendor = ANY (v_vendor)
+      AND device.spec.model = ANY (v_model)
+    GROUP BY
+        w.daily_window, device.spec.vendor
+    ORDER BY
+        2, w.daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    vendor as metric,
+    total
+FROM
+    dashboard_device.devices_by_vendors(
+        $__timeFrom(),
+        $__timeTo(),
+        ARRAY[$class],
+        ARRAY[$vendor],
+        ARRAY[$model]
+    );
+*/
+
+------- PANEL Active Devices (Graph) -------
+CREATE OR REPLACE FUNCTION dashboard_device.active_devices_graph(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE,
+        v_class TEXT[],
+        v_vendor TEXT[],
+        v_model TEXT[]
+)
+    RETURNS TABLE (
+        daily_window TIMESTAMP,
+        total BIGINT,
+        errors BIGINT,
+        valids BIGINT
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        daily_window,
+        COUNT(*) total,
+        COUNT(d.error) errors,
+        COUNT(*) - COUNT(d.error) valids
+    FROM
+        device.weekly_reports_sliding w
+        INNER JOIN device.ts_device d ON w.report_id = d.report_id
+        INNER JOIN device.device ON d.device_id = device.device.id
+        INNER JOIN device.spec ON device.device.spec_id = device.spec.id
+    WHERE
+            daily_window BETWEEN time_from AND time_to
+        AND device.spec.class = ANY (v_class::device.class[])
+        AND device.spec.vendor = ANY (v_vendor)
+        AND device.spec.model = ANY (v_model)
+    GROUP BY
+        daily_window
+    ORDER BY
+        daily_window
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    total AS "Total",
+    errors AS "Reporting Invalid Telemetry",
+    valids AS "Reporting valid Telemetry"
+FROM
+    dashboard_device.active_devices_graph(
+        $__timeFrom(),
+        $__timeTo(),
+        ARRAY[$class],
+        ARRAY[$vendor],
+        ARRAY[$model]
+    );
+*/
+
+------- PANEL Distinct Hosts - $vendor -------
+CREATE OR REPLACE FUNCTION dashboard_device.distinct_hosts(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE,
+        v_class TEXT[],
+        v_vendor TEXT[],
+        v_model TEXT[]
+)
+    RETURNS TABLE (
+        daily_window TIMESTAMP,
+        total BIGINT
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        w.daily_window,
+        COUNT(DISTINCT(device.device.host_id))
+    FROM
+        device.weekly_reports_sliding w
+        INNER JOIN device.ts_device ON w.report_id = device.ts_device.report_id
+        INNER JOIN device.device ON device.ts_device.device_id = device.device.id
+        INNER JOIN device.spec ON device.device.spec_id = device.spec.id
+    WHERE
+        w.daily_window BETWEEN time_from AND time_to
+      AND device.spec.class = ANY (v_class::device.class[])
+      AND device.spec.vendor = ANY (v_vendor)
+      AND device.spec.model = ANY (v_model)
+    GROUP BY
+        w.daily_window
+    ORDER BY
+        w.daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    total AS "Distinct Hosts"
+FROM
+    dashboard_device.distinct_hosts(
+        $__timeFrom(),
+        $__timeTo(),
+        ARRAY[$class],
+        ARRAY[$vendor],
+        ARRAY[$model]
+    );
+*/
+
+------- PANEL Distinct Models - $vendor -------
+CREATE OR REPLACE FUNCTION dashboard_device.distinct_models(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE,
+        v_vendor TEXT[],
+        v_model TEXT[]
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP,
+        total BIGINT
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        daily_window,
+        COUNT(DISTINCT(device.spec.model))
+    FROM
+        device.weekly_reports_sliding w
+        INNER JOIN device.ts_device ON w.report_id = device.ts_device.report_id
+        INNER JOIN device.device ON device.ts_device.device_id = device.device.id
+        INNER JOIN device.spec ON device.device.spec_id = device.spec.id
+    WHERE
+        w.daily_window BETWEEN time_from AND time_to
+        AND device.spec.vendor = ANY (v_vendor)
+        AND device.spec.model = ANY (v_model)
+    GROUP BY
+        w.daily_window
+    ORDER BY
+        w.daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    total AS "Distinct Models"
+FROM
+    dashboard_device.distinct_models(
+        $__timeFrom(),
+        $__timeTo(),
+        ARRAY[$vendor],
+        ARRAY[$model]
+    );
+*/
+
+------- PANEL Devices by Types - $vendor -------
+CREATE OR REPLACE FUNCTION dashboard_device.devices_by_type(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE,
+        v_vendor TEXT[]
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP,
+        total BIGINT,
+        device_type TEXT
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        w.daily_window,
+        COUNT(*),
+        device.spec.type::TEXT
+    FROM
+        device.weekly_reports_sliding w
+        INNER JOIN device.ts_device ON w.report_id = device.ts_device.report_id
+        INNER JOIN device.device ON device.ts_device.DEVICE_ID = device.device.id
+        INNER JOIN device.spec ON device.device.SPEC_ID = device.spec.id
+    WHERE
+        w.daily_window BETWEEN time_from AND time_to
+        AND device.spec.type IS NOT NULL
+        AND device.spec.vendor = ANY (v_vendor)
+    GROUP BY
+        w.daily_window, device.spec.type
+    ORDER BY
+        w.daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    total,
+    device_type AS metric
+FROM
+    dashboard_device.devices_by_type(
+        $__timeFrom(),
+        $__timeTo(),
+        ARRAY[$vendor]
+    );
+*/
+
+------- PANEL SSD Devices by Interface - $vendor -------
+CREATE OR REPLACE FUNCTION dashboard_device.ssd_devices_by_interface(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE,
+        v_vendor TEXT[]
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP,
+        interface TEXT,
+        total BIGINT
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        w.daily_window,
+        device.spec.interface::TEXT, -- maybe text []?
+        COUNT(*)
+    FROM
+        device.weekly_reports_sliding w
+        INNER JOIN device.ts_device ON w.report_id = device.ts_device.report_id
+        INNER JOIN device.device ON device.ts_device.DEVICE_ID = device.device.id
+        INNER JOIN device.spec ON device.device.SPEC_ID = device.spec.id
+    WHERE
+        w.daily_window BETWEEN time_from AND time_to
+        AND device.spec.vendor = ANY (v_vendor)
+        AND
+            (device.spec.type::text = 'ssd'
+            OR
+            device.spec.type::text = 'nvme')
+    GROUP BY
+        w.daily_window, device.spec.interface
+    ORDER BY
+        2, w.daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    interface as metric,
+    total
+FROM
+    dashboard_device.ssd_devices_by_interface(
+        $__timeFrom(),
+        $__timeTo(),
+        ARRAY[$vendor]
+    );
+*/
+
+------- PANEL HDD Devices by Interface - $vendor -------
+CREATE OR REPLACE FUNCTION dashboard_device.hdd_devices_by_interface(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE,
+        v_vendor TEXT[]
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP,
+        interface TEXT,
+        total BIGINT
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        w.daily_window,
+        device.spec.interface::TEXT,
+        COUNT(*)
+    FROM
+        device.weekly_reports_sliding w
+        INNER JOIN device.ts_device ON w.report_id = device.ts_device.report_id
+        INNER JOIN device.device ON device.ts_device.DEVICE_ID = device.device.id
+        INNER JOIN device.spec ON device.device.SPEC_ID = device.spec.id
+      WHERE
+        w.daily_window BETWEEN time_from AND time_to
+        AND device.spec.vendor = ANY (v_vendor)
+        AND device.spec.type::text = 'hdd'
+    GROUP BY
+        w.daily_window, device.spec.interface
+    ORDER BY
+        w.daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    interface as metric,
+    total
+FROM
+    dashboard_device.hdd_devices_by_interface(
+        $__timeFrom(),
+        $__timeTo(),
+        ARRAY[$vendor]
+    );
+*/
+
+------- PANEL Total Capacity - $vendor -------
+CREATE OR REPLACE FUNCTION dashboard_device.total_capacity_graph(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE,
+        v_class TEXT[],
+        v_vendor TEXT[],
+        v_model TEXT[]
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP,
+        total NUMERIC
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        w.daily_window,
+        SUM(capacity)
+    FROM
+        device.weekly_reports_sliding w
+        INNER JOIN device.ts_device ON w.report_id = device.ts_device.report_id
+        INNER JOIN device.device ON device.ts_device.DEVICE_ID = device.device.id
+        INNER JOIN device.spec ON device.device.SPEC_ID = device.spec.id
+    WHERE
+        w.daily_window BETWEEN time_from AND time_to
+        AND device.spec.class = ANY (v_class::device.class[])
+        AND device.spec.vendor = ANY (v_vendor)
+        AND device.spec.model = ANY (v_model)
+    GROUP BY
+        daily_window
+    ORDER BY
+        daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    total AS "Total Capacity"
+FROM
+    dashboard_device.total_capacity_graph(
+        $__timeFrom(),
+        $__timeTo(),
+        ARRAY[$class],
+        ARRAY[$vendor],
+        ARRAY[$model]
+    );
+*/
+
+------- PANEL Devices by HW RAID -------
+CREATE OR REPLACE FUNCTION dashboard_device.devices_by_hw_raid(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP,
+        vendor TEXT,
+        total BIGINT
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        w.daily_window,
+        device.spec.vendor,
+        COUNT(*)
+    FROM
+        device.weekly_reports_sliding w
+        INNER JOIN device.ts_device ON w.report_id = device.ts_device.report_id
+        INNER JOIN device.device ON device.ts_device.DEVICE_ID = device.device.id
+        INNER JOIN device.spec ON device.device.SPEC_ID = device.spec.id
+    WHERE
+        w.daily_window BETWEEN time_from AND time_to
+        AND device.spec.class = 'hw_raid'
+    GROUP BY
+        w.daily_window, device.spec.vendor
+    ORDER BY
+        2, w.daily_window;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    vendor as metric,
+    total
+FROM
+    dashboard_device.devices_by_hw_raid(
+        $__timeFrom(),
+        $__timeTo()
+    );
+*/
+
+------- PANEL Devices by Class -------
+CREATE OR REPLACE FUNCTION dashboard_device.devices_by_class(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP,
+        total BIGINT,
+        class device.class
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        w.daily_window,
+        COUNT(*),
+        device.spec.class
+    FROM
+        device.weekly_reports_sliding w
+        INNER JOIN device.ts_device ON w.report_id = device.ts_device.report_id
+        INNER JOIN device.device ON device.ts_device.DEVICE_ID = device.device.id
+        INNER JOIN device.spec ON device.device.SPEC_ID = device.spec.id
+    WHERE
+        w.daily_window BETWEEN time_from AND time_to
+        AND device.spec.class != 'unknown'
+    GROUP BY
+        w.daily_window, device.spec.class
+    ORDER BY
+        w.daily_window, device.spec.class;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    total,
+    class AS metric
+FROM
+    dashboard_device.devices_by_class(
+        $__timeFrom(),
+        $__timeTo()
+    );
+*/
+
+------- PANEL Invalid Telemetry Reports by Device Class -------
+CREATE OR REPLACE FUNCTION dashboard_device.invalid_reports_by_device_class(
+        time_from TIMESTAMP WITH TIME ZONE,
+        time_to TIMESTAMP WITH TIME ZONE,
+        v_class TEXT[]
+    )
+    RETURNS TABLE (
+        daily_window TIMESTAMP,
+        total BIGINT,
+        class device.class
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        w.daily_window,
+        COUNT(*),
+        device.spec.class
+    FROM
+        device.weekly_reports_sliding w
+        INNER JOIN device.ts_device ON w.report_id = device.ts_device.report_id
+        INNER JOIN device.device ON device.ts_device.DEVICE_ID = device.device.id
+        INNER JOIN device.spec ON device.device.SPEC_ID = device.spec.id
+    WHERE
+        w.daily_window BETWEEN time_from AND time_to
+        AND device.spec.class = ANY (v_class::device.class[])
+        AND device.ts_device.error IS NOT NULL
+    GROUP BY
+        w.daily_window, device.spec.class
+    ORDER BY
+        w.daily_window, device.spec.class;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    $__timeGroup(daily_window, '1d', 0),
+    total AS "Empty Reports",
+    class AS metric
+FROM
+    dashboard_device.invalid_reports_by_device_class(
+        $__timeFrom(),
+        $__timeTo(),
+        ARRAY[$class]
+    );
+*/
+
+
+------- DASHBOARD: Devices / Distinct Model Count -------
+
+/*
+------- VARIABLE: class -------
+Same as Devices / Main
+
+------- VARIABLE: vendor -------
+Same as Devices / Main
+*/
+
+------- PANEL Distinct Models Count per Vendor - All-time -------
+CREATE OR REPLACE FUNCTION dashboard_device.models_count_per_vendor(
+        v_vendor TEXT[]
+    )
+    RETURNS TABLE (
+        vendor TEXT,
+        models BIGINT,
+        devices NUMERIC
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        a.vendor vendor,
+        COUNT(a.model) models,
+        SUM(a.devices) devices
+    FROM (
+        SELECT
+            device.spec.vendor,
+            device.spec.model,
+            device.spec.type,
+            device.spec.interface,
+            device.spec.class,
+            COUNT(device.id) devices
+        FROM
+            device.spec
+            INNER JOIN device.device ON device.device.spec_id = device.spec.id
+        GROUP BY
+            device.spec.id
+        ORDER BY
+            devices desc
+        ) a
+    WHERE
+        a.vendor = ANY (v_vendor)
+    GROUP BY
+        a.vendor
+    ORDER BY
+        models DESC;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    vendor,
+    models,
+    devices
+FROM
+    dashboard_device.models_count_per_vendor(
+        ARRAY[$vendor]
+    );
+*/
+
+
+------- DASHBOARD: Devices / Models per Vendor -------
+
+/*
+------- VARIABLE: class -------
+Same as Devices / Main
+
+------- VARIABLE: vendor -------
+Same as Devices / Main
+
+------- VARIABLE: model -------
+Same as Devices / Main
+*/
+
+------- PANEL Models per Vendor -------
+CREATE OR REPLACE FUNCTION dashboard_device.models_per_vendor(
+        v_class TEXT[],
+        v_vendor TEXT[],
+        v_model TEXT[]
+    )
+    RETURNS TABLE (
+        vendor TEXT,
+        model TEXT,
+        type device.type, -- enum
+        interface device.interface, -- enum
+        class device.class, -- enum
+        capacity BIGINT,
+        devices BIGINT
+    )
+LANGUAGE SQL SECURITY DEFINER
+AS $$
+    SELECT
+        device.spec.vendor vendor,
+        device.spec.model model,
+        device.spec.type,
+        device.spec.interface,
+        device.spec.class,
+        device.spec.capacity,
+        COUNT(device.id) devices
+    FROM
+        device.spec
+        INNER JOIN device.device ON device.device.spec_id = device.spec.id
+    WHERE
+            device.spec.class = ANY (v_class::device.class[])
+        AND device.spec.vendor = ANY (v_vendor)
+        AND device.spec.model = ANY (v_model)
+    GROUP BY
+        device.spec.id
+    ORDER BY
+        vendor, model;
+$$;
+
+/*
+-- Dashboard query:
+SELECT
+    vendor,
+    model,
+    type,
+    interface,
+    class,
+    capacity,
+    devices
+FROM
+    dashboard_device.models_per_vendor(
+        ARRAY[$class],
+        ARRAY[$vendor],
+        ARRAY[$model]
+    );
+*/

--- a/db_create_device.sql
+++ b/db_create_device.sql
@@ -26,10 +26,8 @@ GRANT CREATE ON SCHEMA device TO grafana;
 GRANT ALL ON ALL TABLES IN SCHEMA device TO grafana;
 GRANT ALL ON ALL SEQUENCES IN SCHEMA device TO grafana;
 
--- May need to run these commands as user 'postgres'.
 GRANT USAGE ON SCHEMA device TO grafana_ro;
 GRANT SELECT ON ALL TABLES IN SCHEMA device TO grafana_ro;
-GRANT SELECT ON device.weekly_reports_sliding TO grafana_ro;
 
 ALTER DEFAULT PRIVILEGES
     IN SCHEMA device
@@ -106,8 +104,9 @@ CREATE TABLE device.smart_sata (
     ts              TIMESTAMP,
     attr_id         INTEGER,
     attr_name       VARCHAR(128),
-    attr_val        BIGINT,
-    attr_val_str    VARCHAR(128),
+    attr_raw        BIGINT,
+    attr_raw_str    VARCHAR(128),
+    attr_norm       BIGINT,
     attr_worst      BIGINT
 );
 
@@ -165,6 +164,8 @@ CREATE MATERIALIZED VIEW device.weekly_reports_sliding AS
 
 -- Run this command as user 'postgres', since user 'telemetry' is not part of 'grafana' role.
 ALTER MATERIALIZED VIEW device.weekly_reports_sliding OWNER TO grafana;
+
+GRANT SELECT ON device.weekly_reports_sliding TO grafana_ro;
 
 -- Holds (vendor, model) mappings results - for debugging purposes only.
 -- It can be removed at some point.

--- a/db_create_device.sql
+++ b/db_create_device.sql
@@ -1,0 +1,177 @@
+/*
+Note: This script DROPS 'device' schema's tables and content ENTIRELY, then recreates it.
+Use it with caution.
+Other permissions are managed in db_create_cluster.sql and db_create_roles.sql.
+*/
+
+-- Uncomment this block when you really mean it:
+/*
+DROP TABLE device.spec CASCADE;
+DROP TABLE device.device CASCADE;
+DROP TABLE device.ts_device CASCADE;
+DROP TABLE device.smart_sata CASCADE;
+DROP TABLE device.smart_nvme CASCADE;
+DROP TABLE device.smart_nvme_vs CASCADE;
+DROP TABLE device.mapping; -- Remove this when we remove 'device.mapping' table
+-- These types will not be dropped if they are referred by tables in other schemas:
+DROP TYPE IF EXISTS device.interface;
+DROP TYPE IF EXISTS device.class;
+DROP TYPE IF EXISTS device.type;
+*/
+
+CREATE SCHEMA device;
+
+GRANT USAGE ON SCHEMA device TO grafana;
+GRANT CREATE ON SCHEMA device TO grafana;
+GRANT ALL ON ALL TABLES IN SCHEMA device TO grafana;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA device TO grafana;
+
+-- May need to run these commands as user 'postgres'.
+GRANT USAGE ON SCHEMA device TO grafana_ro;
+GRANT SELECT ON ALL TABLES IN SCHEMA device TO grafana_ro;
+GRANT SELECT ON device.weekly_reports_sliding TO grafana_ro;
+
+ALTER DEFAULT PRIVILEGES
+    IN SCHEMA device
+    GRANT SELECT ON TABLES TO grafana_ro;
+
+-- Grant access to user 'grafana' on future tables & sequences in schema device
+ALTER DEFAULT PRIVILEGES
+    FOR ROLE telemetry
+    IN SCHEMA device
+    GRANT ALL ON TABLES TO grafana;
+
+ALTER DEFAULT PRIVILEGES
+    FOR ROLE telemetry
+    IN SCHEMA device
+    GRANT ALL ON SEQUENCES TO grafana;
+
+CREATE TYPE device.interface AS ENUM ('ata', 'sata', 'sas', 'scsi', 'nvme');
+CREATE TYPE device.class AS ENUM ('hw_raid', 'normal', 'vm', 'unknown');
+
+/*
+We could distinguish between 'spinning' and 'flash' types, however since we want
+to display distributions of (hdd, ssd, nvme) we choose to include 'nvme' here
+as a type, even though it's an interface over 'flash'. This allows for easier
+querying. We assume:
+
+spinning --> hdd
+                                  --> sata/sas --> ssd
+                                 /
+flash    --> (check interface) --
+                                 \
+                                  --> nvme --> nvme
+*/
+CREATE TYPE device.type AS ENUM ('hdd', 'ssd', 'nvme');
+
+-- Holds a row per device vendor and model with generic information about that model.
+CREATE TABLE device.spec (
+    id              SERIAL PRIMARY KEY,
+    vendor          VARCHAR(128),
+    model           VARCHAR(128),
+    type            device.type,
+    interface       device.interface,
+    class           device.class,
+    capacity        BIGINT,
+    UNIQUE          (vendor, model)
+);
+
+-- Holds data that is unique per device and doesn't change over time.
+CREATE TABLE device.device (
+    id              SERIAL PRIMARY KEY,
+    -- vmu format: vendor_model_<uuid>. That's the original anonymized device id generated on the client side.
+    vmu             VARCHAR(128) NOT NULL UNIQUE,
+    spec_id         INTEGER REFERENCES device.spec(id) NOT NULL, -- No 'ON DELETE CASCADE' since spec_id is one-to-many
+    host_id         VARCHAR(128)
+);
+
+-- Time series table that holds a reference of each device report.
+-- Mainly used to create the weekly_reports_sliding materialized view.
+CREATE TABLE device.ts_device (
+    report_id   INTEGER REFERENCES public.device_report(id) NOT NULL PRIMARY KEY,
+    device_id   INTEGER NOT NULL REFERENCES device.device(id) ON DELETE CASCADE,
+    ts          TIMESTAMP,
+    error       TEXT
+);
+
+/*
+device_id is a serial id generated on inserts to device.device table.
+report_id is a serial id generated on inserts to public.device_report table.
+We include both columns in these tables since it's significantly easier to query this way
+(reduces inevitable 'joins').
+*/
+CREATE TABLE device.smart_sata (
+    device_id       INTEGER NOT NULL REFERENCES device.device(id) ON DELETE CASCADE,
+    report_id       INTEGER REFERENCES public.device_report(id) NOT NULL,
+    ts              TIMESTAMP,
+    attr_id         INTEGER,
+    attr_name       VARCHAR(128),
+    attr_val        BIGINT,
+    attr_val_str    VARCHAR(128),
+    attr_worst      BIGINT
+);
+
+CREATE TABLE device.smart_nvme (
+    device_id       INTEGER NOT NULL REFERENCES device.device(id) ON DELETE CASCADE,
+    report_id       INTEGER REFERENCES public.device_report(id) NOT NULL,
+    ts              TIMESTAMP,
+    attr_name       VARCHAR(128),
+    attr_val        BIGINT,
+    attr_val_err    TEXT --In case attr_val could not be retrieved. This column is for monitoring,
+    -- and could probably be removed at some point assuming it's empty.
+);
+
+-- Device's vendor specific extended SMART 'log page contents'
+CREATE TABLE device.smart_nvme_vs (
+    device_id       INTEGER NOT NULL REFERENCES device.device(id) ON DELETE CASCADE,
+    report_id       INTEGER REFERENCES public.device_report(id) NOT NULL,
+    ts              TIMESTAMP,
+    attr_name       VARCHAR(128),
+    attr_val        BIGINT,
+    attr_val_err    TEXT -- Same as in device.smart_nvme
+);
+
+/*
+When Grafana draws a graph with a resolution of a day, it expects the DB
+query to return a data point per day. A device may report less frequently
+than once a day, thus the DB query will return a spike on the day that
+the device reports, and a drop on days it doesn't.
+To normalize this, we create a materialized view that for each day holds
+a list of all reports that occurred on the previous week - only the most
+recent report for each device within that previous week.
+We use a materialized view because it's much faster than a regular view.
+We update the materialized view in import_devices.py, which creates it
+from scratch with the most recent reports.
+*/
+CREATE MATERIALIZED VIEW device.weekly_reports_sliding AS
+    SELECT
+        DISTINCT ON(daily_window, device_id)
+        daily_window,
+        report_id
+        /*
+        GENERATE_SERIES generates a table with a single column 'daily_window'
+        which holds all the days (a row per day) between the first report
+        and *tomorrow*. Day format is 'YYYY-MM-DD 00:00:00'.
+        */
+    FROM
+        device.ts_device d,
+        GENERATE_SERIES('2019-03-01', now()::date + interval '1' day, interval '1' day) daily_window
+    WHERE
+        d.ts BETWEEN daily_window - interval '7' day AND daily_window + interval '1' day
+    ORDER BY
+        daily_window,
+        device_id,
+        d.ts DESC;
+
+-- Run this command as user 'postgres', since user 'telemetry' is not part of 'grafana' role.
+ALTER MATERIALIZED VIEW device.weekly_reports_sliding OWNER TO grafana;
+
+-- Holds (vendor, model) mappings results - for debugging purposes only.
+-- It can be removed at some point.
+CREATE TABLE device.mapping (
+    id                SERIAL PRIMARY KEY,
+    i_vendor          VARCHAR(128), -- Input vendor
+    i_model           VARCHAR(128), -- Input model
+    o_vendor          VARCHAR(128), -- Output vendor
+    o_model           VARCHAR(128)  -- Output model
+);

--- a/db_create_roles.sql
+++ b/db_create_roles.sql
@@ -1,4 +1,3 @@
-
 --CREATE USER grafana WITH PASSWORD '<PASSWORD>';
 --CREATE USER grafana_ro WITH PASSWORD '<PASSWORD>';
 GRANT USAGE ON SCHEMA grafana TO grafana, grafana_ro;
@@ -56,3 +55,16 @@ GRANT USAGE ON LANGUAGE SQL to postgres, telemetry;
 REVOKE ALL ON SCHEMA public FROM PUBLIC;
 REVOKE CONNECT, TEMPORARY ON DATABASE telemetry FROM PUBLIC;
 REVOKE CONNECT ON DATABASE postgres FROM PUBLIC;
+
+-- dashboard_device schema roles:
+CREATE SCHEMA IF NOT EXISTS dashboard_device;
+
+GRANT USAGE ON SCHEMA dashboard_device TO dashboard, grafana, grafana_ro;
+GRANT CREATE ON SCHEMA dashboard_device TO grafana;
+GRANT ALL ON ALL TABLES IN SCHEMA dashboard_device TO grafana;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA dashboard_device TO dashboard, grafana_ro;
+
+ALTER DEFAULT PRIVILEGES
+    FOR ROLE grafana
+    IN SCHEMA dashboard_device
+    GRANT EXECUTE ON FUNCTIONS TO dashboard;

--- a/import_devices.py
+++ b/import_devices.py
@@ -1,0 +1,566 @@
+#! /usr/bin/env python3
+# vim: ts=4 sw=4 expandtab
+
+import dbhelper
+import psycopg2
+import psycopg2.extras
+import json
+import sys
+import time
+import re
+from pathlib import Path
+from os import listdir
+from os.path import isfile, join
+
+# Data Source Name file
+DSN = '/opt/telemetry/grafana.dsn'
+
+# Device tables are created via db_create_device.sql (DDL file)
+
+
+# Flatten
+#     "crc_error_count": {
+#         "normalized": 100,
+#         "raw": 0
+#     },
+# To
+#     "crc_error_count_normalized": 100,
+#     "crc_error_count_raw": 0
+def parse_nvme_vendor(prefix, data, result):
+    if not isinstance(data, dict):
+        result[prefix] = data
+    else:
+        for k in data.keys():
+            parse_nvme_vendor(prefix + '_' + k, data[k], result)
+
+"""
+Due to prevalent inconsistencies in reporting the correct device's vendor and
+model names, we must screen all new records, and make sure they can be mapped
+to their correct values.
+map_input() takes the original vendor and model "raw" names of a reporting
+device, and returns their correct values, and the device's class ('hw raid',
+'vm', 'normal', or 'unknown' otherwise).
+"""
+def map_input(vendor, model):
+    """
+    Items in 'mapping' tuples are in this order:
+    (from_vendor, from_model, to_vendor, to_model, class)
+    Case is ignored in the regex search itself.
+    Order matters! Put strict cases tuples before looser ones.
+    Otherwise, order by alphabet of the first item in each tuple.
+
+    Keep model names uppercased, so dashboard display is consistent.
+
+    In case we add new classes (in addition to "hw_raid", "vm", etc.),
+    we need to update the corresponding enum (device.class) in the DDL file.
+
+    Mapping example:
+        map_input("HUSMR108", "CLAR800")
+    Matched rule:
+        ("(HUSM[MR]\d{3})", "(CLAR\d+)", "hgst", "$v0-$m0", "normal")
+    Output:
+        "hgst", "HUSMR108-CLAR800", "normal"
+    """
+    mapping = [
+        # First check for HW RAID controllers:
+        ("3PARdata", "VV", None, None, "hw_raid"), # This is SAN, we tag it as HW RAID for now
+        ("(asr7160)", ".*", "adaptec", "$v0", "hw_raid"),
+        ("avago", "SMC.*", None, None, "hw_raid"),
+        ("hp", "logical_volume", None, None, "hw_raid"),
+        ("ibm", "ServeRAID.*", None, None, "hw_raid"),
+        ("ibm", "2145.*", None, None, "hw_raid"),
+        ("ibm", "1746_FAStT.*", None, None, "hw_raid"),
+        ("dell", "PERC.*", None, None, "hw_raid"),
+        ("lenovo", "RAID_930.*", None, None, "hw_raid"),
+        ("lsi", ".*", None, None, "hw_raid"),
+        ("(servera)", "(.*)", "unknown_raid_01", "$v0-$m0", "hw_raid"), # This might be SAN
+
+        # Then check for devices behind VMs:
+        ("0EMAZ-00WJTA", "", None, None, "vm"), # This can be considered as 'invalid', we tag it as VM for now
+        ("amazon", "ELASTIC_BLOCK_STORE", None, None, "vm"),
+        ("centos-.*", ".*", None, None, "vm"),
+        ("Generic", "DISK.*", None, None, "vm"),
+        ("hc", "VOLUME", None, None, "vm"),
+        ("ORCL-VBOX.*", ".*", None, None, "vm"),
+        ("qemu", ".*", None, None, "vm"),
+        ("virtual", "disk", None, None, "vm"),
+        ("volume", ".*", None, None, "vm"),
+        ("vbox", "HARDDISK", None, None, "vm"),
+        ("vmware", ".*", None, None, "vm"),
+
+        # Then the rest:
+        ("3E128-TS2-550B01", "", "oracle", "3E128-TS2-550B01", "normal"),
+        ("ADATA", "SX8200PNP", None, None, "normal"),
+        ("APPLE", "HDD_HTS541010A9E662", None, None, "normal"),
+        ("ata", "(st\d+.*)", "seagate", "$m0", "normal"),
+        ("ata", "ocz.*", "ocz", None, "normal"),
+        ("crucial", "ct\d.*", None, None, "normal"),
+        # Cases like "CT1000MX500SSD1", "CT2000MX500SSD1", "CT240BX200SSD1"
+        ("(CT\d+.*[BM]X.*SSD1)", "", "crucial", "$v0", "normal"),
+        ("dell", "Express_Flash.*", None, None, "normal"),
+        # Cases like v: GB1000EAFJL   m: None
+        ("(GB\d{4}EAFJ[A-Z]+)", ".*", "hp", "$v0", "normal"),
+        ("gigabyte", "GP-GSTFS31120GNTD", None, None, "normal"),
+        # Cases like v: hgst   m: SDLL1DLR480GCAA1:
+        ("hgst", "[A-Z]{4}\d[A-Z]{3}\d{3}[A-Z]{4}\d", None, None, "normal"),
+        ("hgst", "h.*", None, None, "normal"),
+        # Cases like "H101414SCSUN146G_000915EKHD4A_______"
+        ("hitachi", ".*(H101414SCSUN146G).*", "hgst", "$m0", "normal"),
+        ("hitachi", "h.*", "hgst", None, "normal"),
+        ("hp", "[A-Z]{2}\d{4}[A-Z]{5}", None, None, "normal"),
+        # Cases like "HUSMR1680ASS204"
+        ("(HU.*\d+A[LS].*\d+)", "", "hgst", "$v0", "normal"),
+        # Cases like: vendor: "HUSMR108", model: "CLAR800"
+        ("(HUSM[MR]\d{3})", "(CLAR\d+)", "hgst", "$v0-$m0", "normal"),
+        ("intel", "ssd.*", None, None, "normal"),
+        ("JMicron", "", None, "UNKNOWN", "normal"),
+        # Cases like: v: kingston   m: SHSS37A480G
+        ("kingston", "S.*G", None, None, "normal"),
+
+        # Cases like: MB4000GVYZK, MB6000GEFNB, MB8000GFECR, MB1000EAMZE, MB8000GFECR, MK0800GCTZB
+        ("(M.\d{4}[A-Z]{5})", "", "hp", "$v0", "normal"),
+        # Cases like
+        #    v: MG06ACA10TE   m: 00YK043D7A01892LEN
+        #    v: MG06ACA10TE   m: _________00YK043D7A01892LEN
+        ("(MG06ACA10TE)", "_*00YK043D7A01892LEN", "toshiba", "$v0", "normal"),
+        ("(MG04ACA400N)", "_________49Y6003_49Y6006LEN", "toshiba", "$v0", "normal"),
+        # Cases like MKNSSDRE1TB
+        ("(MKNSSDRE\d+TB)", "", "mushkin", "$v0", "normal"),
+        # Cases like MT0800KEXUU
+        ("(MT0800KEXUU)", "", "hp", "$v0", "normal"),
+        ("(MTFDDAK480TD[CN])", "", "micron", "$v0", "normal"),
+        ("(MTFDHBG800MCG-1AN1ZABYY)", "", "micron", "$v0", "normal"),
+        ("(C400-MTFDDAK256M)", "", "micron", "$v0", "normal"),
+        ("micron", "\d{4}_.*", None, None, "normal"),
+        ("micron", "mt.*", None, None, "normal"),
+        ("(MZ7LH480HAHQ0D3)", "", "dell", "$v0", "normal"),
+        ("(MZ7LM240HCGR-000v3)", "00YC391_00YC394LEN.*", "samsung", "$v0", "normal"),
+        ("NA", "HUA721010KLA330", "hgst", "HUA721010KLA330", "normal"),
+        ("ocz", "INTREPID_3800", None, None, "normal"),
+        ("(OCZ-REVODRIVE3)", "(X)", "ocz", "$v0-$m0", "normal"),
+        ("sabrent", "", None, "UNKNOWN", "normal"),
+        ("sata", "ssd", "phison_oem", "sata_ssd", "normal"),
+        ("SAMSUNG", "843T_240GB", None, None, "normal"),
+        ("samsung", "ssd.*", None, None, "normal"),
+        ("samsung", "[A-Z]{2}.*", None, None, "normal"),
+        ("SanDisk", "SDSSD.*", None, None, "normal"),
+        ("(sdlfgd7r-480g-1ha1)", "", "sandisk", "$v0", "normal"),
+        # Cases like SDLL1MLR032TCAA1
+        ("(SDLL1[DM]LR\d{3}[TG]CAA1)", "", "hgst", "$v0", "normal"),
+        ("seagate", "st.*", None, None, "normal"),
+        # Cases like ST4000NM0024, ST4000NM0035
+        ("(st\d{4}nm\d{4})", "__.*", "seagate", "$v0", "normal"),
+        ("ST320LM001", "HN-M320MBB", "samsung", "ST320LM001_HN-M320MBB", "normal"),
+        ("(st.*)", "", "seagate", "$v0", "normal"),
+        ("(thnsf8400ccse)", "", "toshiba", "$v0", "normal"),
+        ("TOSHIBA", "DT.*", None, None, "normal"),
+        ("TOSHIBA", "THNSNJ480PCS3", None, None, "normal"),
+        ("TOSHIBA", "HD.*", None, None, "normal"),
+        ("TOSHIBA", "m.*", None, None, "normal"),
+        # Cases like VK000480GWCNQ, VK000480GWJPE
+        ("(VK000480GW[A-Z]{3})", "", "hp", "$v0", "normal"),
+        ("WD", "WD4001FYYG-01SL3", "wdc", None, "normal"),
+        ("WDC", "CL_SN720_SDAQNTW-512G-2000", None, None, "normal"),
+        ("wdc", "_(w.*)", None, "$m0", "normal"),
+        ("wdc", "w.*", None, None, "normal"),
+        ("wdc", "cd_.*", None, None, "normal"),
+    ]
+
+    for m in mapping:
+        v_res = re.search(f"^{m[0]}$", vendor, re.I)
+        m_res = re.search(f"^{m[1]}$", model, re.I)
+
+        if v_res and m_res:
+            d = {}
+            d.update({f"v{i}": v_res.groups()[i] for i in range(len(v_res.groups()))})
+            d.update({f"m{i}": m_res.groups()[i] for i in range(len(m_res.groups()))})
+
+            to_vendor = m[2]
+            if to_vendor is not None:
+                for k, v in d.items():
+                    to_vendor = to_vendor.replace(f"${k}", v)
+            else:
+                to_vendor = vendor;
+
+            to_model = m[3]
+            if to_model is not None:
+                for k, v in d.items():
+                    to_model = to_model.replace(f"${k}", v)
+            else:
+                to_model= model;
+
+            return to_vendor.lower(), to_model.upper(), m[4]
+    """
+    Didn't find any known mapping, return original vendor and model, and class "unknown":
+    We lower() the vendor and upper() the model in order to prevent duplicates in device.spec table,
+    which has a case sensitive composite unique key (vendor, model).
+    """
+    return vendor.lower(), model.upper(), "unknown"
+
+# We process a single report which might be empty, but this (vendor, model) device spec
+# might already have complete data in the DB (retrieved from another device).
+def get_device_type(error, interface, rotation_rate, d_class, r_id):
+    # No smarctl data
+    if error:
+        return None
+    interface = interface.lower() if interface else None
+    if interface == "nvme":
+        return "nvme"
+    else:
+        if rotation_rate is not None:
+            # rotation_rate != 0, meaning it's a hard disk.
+            if rotation_rate:
+                return "hdd"
+            else:
+                return "ssd"
+        # rotation_rate == None  and  interface != nvme
+        # This is weird, unless the device is behind HW RAID or a VM.
+        # Alert in case it's not.
+        elif d_class == "normal":
+            print(f"In report_id {r_id} device class is normal, but type could not be retrieved. Interface: {interface}, rotation_rate: {rotation_rate}.")
+    return None
+
+# Returns the device.spec['id'] or creates a new device.spec record if it does not exist.
+def fetch_spec_id(conn, device_spec):
+    cur = conn.cursor()
+    """
+    It's impossible to run "INSERT" with "ON CONFLICT (id) DO NOTHING",
+    and have the exiting id returned, thus we first check if the record
+    exists in device.spec before trying to insert.
+    """
+    dict_cur_spec = conn.cursor(name='server_side_cursor_s_id', withhold=True, cursor_factory=psycopg2.extras.DictCursor)
+    dict_cur_spec.execute("""SELECT id, type, interface, capacity
+                            FROM device.spec
+                            WHERE vendor = %s AND model = %s
+                            """, (device_spec['vendor'], device_spec['model']))
+
+    # fetchone() returns a None object in case of no results.
+    fetched_spec = dict_cur_spec.fetchone()
+    dict_cur_spec.close()
+
+    """
+    The case where vendor & model exist in the DB, but other spec fields
+    couldn't be retrieved since the report was nearly empty (can happen when
+    smartctl version is < 7.0). In case these fields are empty, we assign
+    their corresponding values from newer reports (which might still be None).
+    """
+    if fetched_spec is not None:
+        need_update = False
+        if fetched_spec['type'] is None and device_spec['type'] is not None:
+            fetched_spec['type'] = device_spec['type']
+            need_update = True
+        if fetched_spec['interface'] is None and device_spec['interface'] is not None:
+            fetched_spec['interface'] = device_spec['interface']
+            need_update = True
+        if fetched_spec['capacity'] is None and device_spec['capacity'] is not None:
+            fetched_spec['capacity'] = device_spec['capacity']
+            need_update = True
+
+        if need_update:
+            cur.execute("""UPDATE device.spec
+                        SET
+                            type = %s,
+                            interface = %s,
+                            capacity = %s
+                        WHERE id = %s
+                        """, (fetched_spec['type'], fetched_spec['interface'], fetched_spec['capacity'], fetched_spec['id']))
+
+        cur.close()
+        return fetched_spec['id']
+
+    # These vendor & model are not in device_spec table, inserting:
+    else:
+        sql = """INSERT INTO device.spec (%s) VALUES %s
+                 RETURNING id"""
+        dbhelper.run_insert(cur, sql, device_spec)
+        fetched_spec = cur.fetchone()
+
+        cur.close()
+        return fetched_spec[0]
+
+def fetch_device_id(cur, device):
+    cur.execute("""SELECT id FROM device.device
+                   WHERE vmu = %s
+                """, (device['vmu'],)) # The ',' in (device['vmu'],) creates a tuple and is mandatory.
+
+    device_id = cur.fetchone()
+
+    # No such device in device table, inserting:
+    if not device_id:
+        sql = """INSERT INTO device.device (%s) VALUES %s
+                RETURNING id"""
+        dbhelper.run_insert(cur, sql, device)
+        device_id = cur.fetchone()
+
+    return device_id[0]
+
+"""
+Some versions of smartctl report certain fields as a dictionary of their
+'n'umeric and 's'tring representations:
+   "blocks": {
+       "n": 7814037168,
+       "s": "7814037168"
+   },
+Newer versions of smartctl do not do that and just report:
+   "blocks": 7814037168
+"""
+def parse_value_by_type(v):
+    if isinstance(v, list):
+        # FIXME: include list type values, like 'temperature_sensors'
+        return None
+    if isinstance(v, dict):
+        if 'n' not in v:
+            raise ValueError("No 'n' in dict")
+        return v['n']
+    else:
+        return v
+
+def populate_device_smart_nvme(cur, smart_attr_nvme, device_id, report_id, ts):
+    for k, v in smart_attr_nvme.items():
+        device_smart_nvme = {}
+        device_smart_nvme['device_id'] = device_id
+        device_smart_nvme['report_id'] = report_id
+        device_smart_nvme['ts']        = ts
+        device_smart_nvme['attr_name'] = k
+        device_smart_nvme['attr_val']  = parse_value_by_type(v)
+
+        if device_smart_nvme['attr_val'] is None:
+            print(f"attr_name: {k} of device report id {report_id}, attr_val is of type list.\n")
+        sql = 'INSERT INTO device.smart_nvme (%s) VALUES %s'
+        dbhelper.run_insert(cur, sql, device_smart_nvme)
+
+# NVMe vendor specific data:
+# TODO: Support newer versions of nvme-cli here and in the telemetry client
+def populate_device_smart_nvme_vs(cur, device, report, device_id, report_id, ts):
+    data = report.get('nvme_smart_health_information_add_log', {})
+    # 'Device stats' is found in Intel drives
+    dev_stats = data.get('Device stats') if data.get('Device stats') else data
+    dev_stats_parsed = {}
+    if dev_stats:
+        for k, v in dev_stats.items():
+            parse_nvme_vendor(k, v, dev_stats_parsed)
+
+    # No nested dictionaries at this point
+    for k, v in dev_stats_parsed.items():
+        device_smart_nvme_vs = {}
+        device_smart_nvme_vs['device_id'] = device_id
+        device_smart_nvme_vs['report_id'] = report_id
+        device_smart_nvme_vs['ts']        = ts
+        device_smart_nvme_vs['attr_name'] = k
+        device_smart_nvme_vs['attr_val']  = v
+
+        sql = 'INSERT INTO device.smart_nvme_vs (%s) VALUES %s'
+        dbhelper.run_insert(cur, sql, device_smart_nvme_vs)
+
+def populate_device_smart_sata(cur, sata_smart_attr, device_id, report_id, ts):
+    for attr in sata_smart_attr.get('table', []):
+        device_smart_sata = {}
+        device_smart_sata['device_id']    = device_id
+        device_smart_sata['report_id']    = report_id
+        device_smart_sata['ts']           = ts
+        device_smart_sata['attr_id']      = attr['id']
+        device_smart_sata['attr_name']    = attr['name']
+        device_smart_sata['attr_val']     = attr['raw']['value']
+        device_smart_sata['attr_val_str'] = attr['raw']['string']
+        device_smart_sata['attr_worst']   = attr['worst']
+
+        sql = 'INSERT INTO device.smart_sata (%s) VALUES %s'
+        dbhelper.run_insert(cur, sql, device_smart_sata)
+
+def import_report(conn, r):
+    cur = conn.cursor()
+    # vmu stands for vendor_model_uuid
+    # (that's the original anonymized device id generated on the client side)
+    vmu = r['device_id']
+    # ts represents SMART scraping time
+    ts = r['report_stamp']
+    rep = json.loads(r['report'])
+    report_id = r['id']
+    error = rep.get('error')
+
+    """
+    Order of insertion into tables:
+      1. device.spec
+      2. device.device     (referencing device.spec['id'])
+      3. device.ts_device  (referencing device.device['id])
+    """
+    device_spec = {}
+    device = {}
+    ts_device = {}
+
+    device['vmu'] = vmu
+    device['host_id'] = rep.get('host_id', None)
+    # verify vmu.count('_') > 1 ?
+    device_spec['vendor'] = vmu[: vmu.find('_')]
+    device_spec['model'] = vmu[vmu.find('_') + 1 : vmu.rfind('_')]
+    device_spec['capacity'] = parse_value_by_type(rep.get('user_capacity', {}).get('bytes'))
+    ts_device['report_id'] = report_id
+    ts_device['ts'] = ts
+    ts_device['error'] = error
+
+    """
+    In device.spec table a device's class can be 'normal' (which means we
+    recognize its vendor and model, and it's not reporting behind a VM or a HW
+    RAID controller). Yet, we may not know its complete spec, because all
+    devices by this spec are reporting invalid telemetry (due to an old version
+    of smartctl, sudoers issues, etc.). In this scenario the record in
+    device.spec table will contain values only for vendor, model, and class,
+    while either type, interface, capacity can be NULL.
+    """
+    new_vendor, new_model, new_class = map_input(device_spec['vendor'], device_spec['model'])
+
+    # Creating a record of the (vendor, model) mapping result for debugging:
+    mapping = {}
+    mapping['i_vendor'] = device_spec['vendor']
+    mapping['i_model'] = device_spec['model']
+    mapping['o_vendor'] = new_vendor
+    mapping['o_model'] = new_model
+
+    sql = """INSERT INTO device.mapping (%s) VALUES %s"""
+    dbhelper.run_insert(cur, sql, mapping)
+
+    # Assigning the new values
+    device_spec['vendor'] = new_vendor
+    device_spec['model'] = new_model
+    device_spec['class'] = new_class
+
+    rotation_rate = rep.get('rotation_rate')
+    interface = rep.get('device', {}).get('protocol')
+    device_spec['interface'] = interface.lower() if interface else None
+
+    """
+    device.spec table holds unique (vendor, model) records and their specifications;
+    There are multiple devices with the same (vendor, model). Some devices report invalid smartctl
+    output - we can derive the correct spec from these which report valid stats alone.
+    """
+    device_spec['type'] = get_device_type(error, device_spec['interface'], rotation_rate, device_spec['class'], report_id)
+    device['spec_id'] = fetch_spec_id(conn, device_spec)
+    device_id = fetch_device_id(cur, device)
+    ts_device['device_id'] = device_id
+
+    sql = """INSERT INTO device.ts_device (%s) VALUES %s"""
+    dbhelper.run_insert(cur, sql, ts_device)
+
+    smart_attr_nvme = rep.get('nvme_smart_health_information_log')
+    if smart_attr_nvme:
+        populate_device_smart_nvme(cur, smart_attr_nvme, device_id, report_id, ts)
+
+    # Device's Vendor Specific extended SMART log page contents.
+    # Currently all records accidentally have this key, filtering nvme only:
+    if device_spec['interface'] == 'nvme' and 'nvme_smart_health_information_add_log' in rep:
+        populate_device_smart_nvme_vs(cur, device, rep, device_id, report_id, ts)
+
+    sata_smart_attr = rep.get('ata_smart_attributes')
+    if sata_smart_attr:
+        populate_device_smart_sata(cur, sata_smart_attr, device_id, report_id, ts)
+
+    # Committing everything as a single transaction
+    conn.commit()
+    cur.close()
+
+"""
+Update records of class "unknown" in device.spec.
+Re-run logic that identifies vendor, model, and class of devices that were
+previously identified as 'unknown' and update them in the DB.
+"""
+def update_unknown_spec(conn):
+    dict_cur_update = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+    dict_cur_update.execute("""SELECT vendor, model, id
+                               FROM device.spec
+                               WHERE class = 'unknown'
+                               ORDER BY id""")
+
+    for r in dict_cur_update:
+        new_vendor, new_model, new_class = map_input(r['vendor'], r['model'])
+        # Nothing to do if class is still unknown:
+        if new_class == "unknown":
+            continue
+        try:
+            cur = conn.cursor()
+            # Update the spec record:
+            cur.execute("""UPDATE device.spec
+                        SET
+                            vendor = %s,
+                            model = %s,
+                            class = %s
+                        WHERE id = %s
+                        """ , (new_vendor.lower(), new_model.upper(), new_class, r['id']))
+
+            conn.commit()
+            cur.close()
+
+        except Exception as e:
+            # These messages help to manually fix any conflict.
+            # We prefer to examine each case rather than auto fix it.
+            print("\n\n")
+            print(f"Exception when updating device.spec.id={r['id']} from vendor={r['vendor']}, model={r['model']}, class=unknown" \
+                    f" to vendor={new_vendor}, model={new_model}, class={new_class}")
+            print(e)
+            print(f"# SELECT * FROM device.spec WHERE id={r['id']} OR (vendor='{new_vendor}' AND model='{new_model}');")
+            new_spec_id = f"(SELECT id FROM device.spec WHERE vendor='{new_vendor}' AND model='{new_model}')"
+            print(f"# old->new # UPDATE device.device SET spec_id={new_spec_id} WHERE spec_id={r['id']};\n" \
+                  f"#   INSERT INTO device.spec_deleted select * from device.spec WHERE id={r['id']};\n" \
+                  f"#   DELETE FROM device.spec WHERE id={r['id']};")
+            print(f"# new->old # UPDATE device.device SET spec_id={r['id']} WHERE spec_id={new_spec_id};\n" \
+                  f"#   INSERT INTO device.spec_deleted select * from device.spec WHERE id={new_spec_id};\n" \
+                  f"#   DELETE FROM device.spec WHERE id={new_spec_id};")
+
+            # We rollback here to clean the connection from possible exceptions
+            conn.rollback()
+
+    dict_cur_update.close()
+
+def main():
+    start_time = time.time()
+    with open(DSN, 'r') as f:
+        dsn_str = f.read().strip()
+
+    conn = psycopg2.connect(dsn_str)
+
+    update_unknown_spec(conn)
+
+    # Create a named server-side cursor
+    dict_cur = conn.cursor(name='server_side_cursor', withhold=True, cursor_factory=psycopg2.extras.DictCursor)
+
+    dict_cur.itersize = 10
+
+    """
+    Fetch only reports which are not in ts_device;
+    COALESCE returns the first non-NULL value, so '0' is
+    the returned id in case ts_device table is empty.
+    This SELECT query is outside of the 'try' block, since we prefer
+    not to refresh materialized view (via finally block) in case this query fails
+    (even though it's okay to do so, it's just not the correct flow).
+    """
+    dict_cur.execute("""SELECT device_id, report_stamp, report, id
+                        FROM public.device_report
+                        WHERE device_report.id > (SELECT COALESCE(MAX(ts_device.report_id), 0)
+                                    FROM device.ts_device)
+                        ORDER BY id""")
+    cnt = 0
+    try:
+        for r in dict_cur:
+            cnt += 1
+            import_report(conn, r)
+    except:
+        print(f"Exception when processing public.device_report.id={r['id']}\n")
+        # Since we insert / update multiple tables in each import_report() call,
+        # we rollback all pending actions to avoid any inconsistencies.
+        conn.rollback()
+        raise
+    finally:
+        # Creating a new cursor in case something happened to the existing one:
+        refresh_cur = conn.cursor()
+        refresh_cur.execute("REFRESH MATERIALIZED VIEW device.weekly_reports_sliding")
+        conn.commit()
+        refresh_cur.close()
+
+        dict_cur.close()
+        end_time = time.time()
+        time_delta = int(end_time - start_time)
+        conn.close()
+        print(f"Processed {cnt} reports in {time_delta} seconds\n")
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/import_devices.py
+++ b/import_devices.py
@@ -360,8 +360,9 @@ def populate_device_smart_sata(cur, sata_smart_attr, device_id, report_id, ts):
         device_smart_sata['ts']           = ts
         device_smart_sata['attr_id']      = attr['id']
         device_smart_sata['attr_name']    = attr['name']
-        device_smart_sata['attr_val']     = attr['raw']['value']
-        device_smart_sata['attr_val_str'] = attr['raw']['string']
+        device_smart_sata['attr_raw']     = attr['raw']['value']
+        device_smart_sata['attr_raw_str'] = attr['raw']['string']
+        device_smart_sata['attr_norm']    = attr['value']
         device_smart_sata['attr_worst']   = attr['worst']
 
         sql = 'INSERT INTO device.smart_sata (%s) VALUES %s'

--- a/tables.txt
+++ b/tables.txt
@@ -1,5 +1,6 @@
 
 CREATE TABLE report (
+       id serial NOT NULL UNIQUE,
        cluster_id VARCHAR(50),
        report_stamp TIMESTAMP,
        report TEXT,
@@ -7,6 +8,7 @@ CREATE TABLE report (
 );
 
 CREATE TABLE device_report (
+       id serial NOT NULL UNIQUE,
        device_id VARCHAR(128),
        report_stamp TIMESTAMP,
        report TEXT,


### PR DESCRIPTION
New files:
  - db_create_device.sql:
    Holds the DDL to create 'device' schema, its time series tables, and
    its types.
  - db_create_dashboard_device.sql:
    Holds the DDL to create 'dashboard_device' schema, which contains
    functions (stored procedures) to be run by read-only user
    'dashboard' in Grafana. These functions return restricted data, adjusted
    to each Grafana panel. This file also holds the queries used in
    Grafana's Devices dashboard.
  - import_devices.py - The script that populates 'device' tables.

Updated files:
  - db_create_roles.sql:
    Added roles permissions for 'dashboard_device' schema.
  - tables.txt:
    Added serial id field to public.report and public.device_report tables.

Signed-off-by: Yaarit Hatuka <yaarit@redhat.com>